### PR TITLE
Add list_contacts tool with CRM contact search by name, email, and phone

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ You can list tools, call them with JSON args, and inspect responses.
 Each tool is described concisely; use an MCP client (e.g., Inspector) to view exact JSON schemas.
 
 * **`list_all_templates`** — List templates & template groups with simplified metadata. Supports `limit`/`offset` pagination (default: 50 items per page).
-* **`list_contacts`** — Search CRM contacts by name or email. Returns id, email, first/last name, and company. Use before `send_invite` to resolve a recipient's email address by their name. Supports `per_page` (default 15, max 100).
+* **`list_contacts`** — Search CRM contacts by name, email, or phone. Returns id, email, first/last name, and company. Use before `send_invite` to resolve a recipient's email address by their name. Supports `per_page` (default 15, max 100).
 * **`list_documents`** — Browse your documents, document groups and statuses. Supports `limit`/`offset` pagination (default: 50 items per page).
 * **`create_from_template`** — Make a document or a group from a template/group.
 * **`send_invite`** — Email invites (documents or groups), ordered recipients supported.

--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ You can list tools, call them with JSON args, and inspect responses.
 Each tool is described concisely; use an MCP client (e.g., Inspector) to view exact JSON schemas.
 
 * **`list_all_templates`** — List templates & template groups with simplified metadata. Supports `limit`/`offset` pagination (default: 50 items per page).
+* **`list_contacts`** — Search CRM contacts by name or email. Returns id, email, first/last name, and company. Use before `send_invite` to resolve a recipient's email address by their name. Supports `per_page` (default 15, max 100).
 * **`list_documents`** — Browse your documents, document groups and statuses. Supports `limit`/`offset` pagination (default: 50 items per page).
 * **`create_from_template`** — Make a document or a group from a template/group.
 * **`send_invite`** — Email invites (documents or groups), ordered recipients supported.

--- a/src/signnow_client/client_other.py
+++ b/src/signnow_client/client_other.py
@@ -4,8 +4,10 @@ SignNow API Client - Other Methods
 Methods for authentication, folders, and other utilities.
 """
 
+import json
 from typing import Any
 
+from signnow_client.models.contacts import CrmContactsResponse
 from signnow_client.models.folders_lite import GetFolderByIdResponseLite, GetFoldersResponseLite
 
 from .models import User
@@ -218,3 +220,57 @@ class OtherClientMixin:
         headers = {"Accept": "application/json", "Authorization": f"Bearer {token}"}
 
         return self._get("/user", headers=headers, validate_model=User)
+
+    def get_contacts(
+        self,
+        token: str,
+        query: str | None = None,
+        per_page: int = 15,
+    ) -> CrmContactsResponse:
+        """Retrieve CRM contacts from SignNow.
+
+        Calls GET /v2/crm/contacts. When ``query`` is provided, serializes
+        a JSON ``filters`` parameter using the ``_OR`` combinator so the API
+        matches on email, first_name, last_name, or full_name (LIKE, % wildcards).
+
+        Filter JSON shape (from API docs)::
+
+            filters=[{"_OR":[
+                {"email":     {"type": "like", "value": "query"}},
+                {"first_name":{"type": "like", "value": "query"}},
+                {"last_name": {"type": "like", "value": "query"}},
+                {"full_name": {"type": "like", "value": "query"}},
+                {"phone":     {"type": "like", "value": "query"}}
+            ]}]
+
+        Args:
+            token: Access token for authentication.
+            query: Optional search string to filter contacts by name or email.
+            per_page: Number of contacts to return per page (1–100, default 15).
+
+        Returns:
+            Validated CrmContactsResponse with list of contacts.
+
+        Raises:
+            SignNowAPIAuthenticationError: Invalid or expired token.
+            SignNowAPIRateLimitError: Rate limit exceeded.
+            SignNowAPIServerError: SignNow backend error.
+        """
+        headers = {"Accept": "application/json", "Authorization": f"Bearer {token}"}
+        params: dict[str, str | int] = {"per_page": per_page, "page": 1}
+
+        stripped_query = (query or "").strip()
+        if stripped_query:
+            params["filters"] = json.dumps([
+                {
+                    "_OR": [
+                        {"email": {"type": "like", "value": stripped_query}},
+                        {"first_name": {"type": "like", "value": stripped_query}},
+                        {"last_name": {"type": "like", "value": stripped_query}},
+                        {"full_name": {"type": "like", "value": stripped_query}},
+                        {"phone": {"type": "like", "value": stripped_query}},
+                    ]
+                }
+            ])
+
+        return self._get("/v2/crm/contacts", headers=headers, params=params, validate_model=CrmContactsResponse)

--- a/src/signnow_client/client_other.py
+++ b/src/signnow_client/client_other.py
@@ -231,7 +231,8 @@ class OtherClientMixin:
 
         Calls GET /v2/crm/contacts. When ``query`` is provided, serializes
         a JSON ``filters`` parameter using the ``_OR`` combinator so the API
-        matches on email, first_name, last_name, or full_name (LIKE, % wildcards).
+        performs a LIKE match against email, first_name, last_name, full_name,
+        and phone simultaneously.
 
         Filter JSON shape (from API docs)::
 
@@ -245,7 +246,7 @@ class OtherClientMixin:
 
         Args:
             token: Access token for authentication.
-            query: Optional search string to filter contacts by name or email.
+            query: Optional search string to filter contacts by name, email, or phone.
             per_page: Number of contacts to return per page (1–100, default 15).
 
         Returns:

--- a/src/signnow_client/models/__init__.py
+++ b/src/signnow_client/models/__init__.py
@@ -4,6 +4,7 @@ SignNow API Data Models
 Pydantic models for SignNow API responses and requests.
 """
 
+from .contacts import *
 from .document_groups import *
 from .other_models import *
 from .templates_and_documents import *
@@ -156,6 +157,11 @@ __all__ = [
     # Document group embedded models
     "CreateDocumentGroupEmbeddedEditorRequest",
     "CreateDocumentGroupEmbeddedSendingRequest",
+    # CRM Contacts
+    "CrmContactPhone",
+    "CrmContactCompany",
+    "CrmContact",
+    "CrmContactsResponse",
     # Other Models
     "OrganizationSetting",
     "DocumentDownloadLinkResponse",

--- a/src/signnow_client/models/contacts.py
+++ b/src/signnow_client/models/contacts.py
@@ -1,0 +1,45 @@
+"""SignNow CRM Contacts API models."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CrmContactPhone(BaseModel):
+    """Phone information embedded in a CRM contact."""
+
+    number: str | None = Field(None, description="Phone number")
+    country_code: str | None = Field(None, description="Country code (e.g. US)")
+
+
+class CrmContactCompany(BaseModel):
+    """Company information embedded in a CRM contact."""
+
+    name: str | None = Field(None, description="Company name")
+
+
+class CrmContact(BaseModel):
+    """Single contact from GET /v2/crm/contacts response.
+
+    Captures all fields returned by the API. The tool layer selects
+    only the subset needed for agent decisions.
+    """
+
+    id: str = Field(..., description="Contact ID")
+    email: str = Field(..., description="Contact email address")
+    first_name: str | None = Field(None, description="First name")
+    last_name: str | None = Field(None, description="Last name")
+    phone: CrmContactPhone | None = Field(None, description="Phone info")
+    company: CrmContactCompany | None = Field(None, description="Company info")
+    description: str | None = Field(None, description="Contact description")
+
+
+class CrmContactsResponse(BaseModel):
+    """Top-level response from GET /v2/crm/contacts.
+
+    Only the ``data`` array is consumed; pagination metadata is intentionally
+    ignored at the tool layer for token efficiency. Extra top-level keys
+    (``meta``, pagination fields) are silently ignored by Pydantic.
+    """
+
+    data: list[CrmContact] = Field(default_factory=list, description="List of contacts")

--- a/src/sn_mcp_server/tools/list_contacts.py
+++ b/src/sn_mcp_server/tools/list_contacts.py
@@ -1,0 +1,55 @@
+"""CRM contact listing functions for SignNow MCP server."""
+
+from __future__ import annotations
+
+from signnow_client import SignNowAPIClient
+
+from .models import ContactItem, ContactListResponse
+
+
+async def _list_contacts(
+    token: str,
+    client: SignNowAPIClient,
+    query: str | None = None,
+    per_page: int = 15,
+) -> ContactListResponse:
+    """Retrieve CRM contacts and curate the response for agent consumption.
+
+    Calls GET /v2/crm/contacts. When ``query`` is provided, the API performs a
+    LIKE match against email, first_name, last_name, and full_name simultaneously
+    using the ``_OR`` filter combinator.
+
+    Returns an empty list when no contacts match — this is not an error.
+
+    Args:
+        token: Access token for SignNow API.
+        client: SignNow API client instance.
+        query: Optional partial string to filter contacts by name or email.
+        per_page: Maximum number of contacts to return (1–100, default 15).
+
+    Returns:
+        ContactListResponse with curated list of matching contacts and their count.
+
+    Raises:
+        ValueError: If ``per_page`` is outside the 1–100 range.
+        SignNowAPIAuthenticationError: If the token is invalid or expired.
+        SignNowAPIRateLimitError: If the SignNow API rate limit is exceeded.
+        SignNowAPIServerError: If SignNow returns a server-side error.
+    """
+    if per_page < 1 or per_page > 100:
+        raise ValueError(f"per_page must be between 1 and 100, got {per_page}")
+
+    api_response = client.get_contacts(token, query=query, per_page=per_page)
+
+    contacts = [
+        ContactItem(
+            id=c.id,
+            email=c.email,
+            first_name=c.first_name,
+            last_name=c.last_name,
+            company=c.company.name if c.company else None,
+        )
+        for c in api_response.data
+    ]
+
+    return ContactListResponse(contacts=contacts, count=len(contacts))

--- a/src/sn_mcp_server/tools/list_contacts.py
+++ b/src/sn_mcp_server/tools/list_contacts.py
@@ -16,15 +16,15 @@ async def _list_contacts(
     """Retrieve CRM contacts and curate the response for agent consumption.
 
     Calls GET /v2/crm/contacts. When ``query`` is provided, the API performs a
-    LIKE match against email, first_name, last_name, and full_name simultaneously
-    using the ``_OR`` filter combinator.
+    LIKE match against email, first_name, last_name, full_name, and phone
+    simultaneously using the ``_OR`` filter combinator.
 
     Returns an empty list when no contacts match — this is not an error.
 
     Args:
         token: Access token for SignNow API.
         client: SignNow API client instance.
-        query: Optional partial string to filter contacts by name or email.
+        query: Optional partial string to filter contacts by name, email, or phone.
         per_page: Maximum number of contacts to return (1–100, default 15).
 
     Returns:

--- a/src/sn_mcp_server/tools/models.py
+++ b/src/sn_mcp_server/tools/models.py
@@ -903,3 +903,28 @@ class SkillResponse(BaseModel):
         default=None,
         description="Skill content in Markdown, front-matter removed (fetch mode only)",
     )
+
+
+# ----------------------------
+# Contacts tool models
+# ----------------------------
+
+
+class ContactItem(BaseModel):
+    """Curated contact information for agent consumption."""
+
+    id: str = Field(..., description="Contact ID")
+    email: str = Field(..., description="Contact email address")
+    first_name: str | None = Field(None, description="First name")
+    last_name: str | None = Field(None, description="Last name")
+    company: str | None = Field(None, description="Company name (flattened from nested company object)")
+
+
+class ContactListResponse(BaseModel):
+    """Response from the list_contacts tool."""
+
+    contacts: list[ContactItem] = Field(
+        default_factory=list,
+        description="Matching contacts (empty list when no contacts match — not an error)",
+    )
+    count: int = Field(..., description="Number of contacts returned in this response")

--- a/src/sn_mcp_server/tools/signnow.py
+++ b/src/sn_mcp_server/tools/signnow.py
@@ -28,9 +28,11 @@ from .embedded_sending import (
     _create_embedded_sending_from_template,
 )
 from .invite_status import _get_invite_status
+from .list_contacts import _list_contacts
 from .list_documents import _list_document_groups
 from .list_templates import _list_all_templates
 from .models import (
+    ContactListResponse,
     CreateEmbeddedEditorFromTemplateResponse,
     CreateEmbeddedEditorResponse,
     CreateEmbeddedInviteFromTemplateResponse,
@@ -1204,5 +1206,65 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
         """
         token, client = _get_token_and_client(token_provider)
         return await _send_invite_reminder(client, token, entity_id, entity_type, email, subject, message, ctx=ctx)
+
+    async def _list_contacts_impl(query: str | None = None, per_page: int = 15) -> ContactListResponse:
+        token, client = _get_token_and_client(token_provider)
+        return await _list_contacts(token, client, query=query, per_page=per_page)
+
+    @mcp.tool(
+        name="list_contacts",
+        description="Search CRM contacts by name or email. Use this tool before send_invite to resolve a recipient's email address by their name." + TOOL_FALLBACK_SUFFIX,
+        annotations=ToolAnnotations(
+            title="List CRM contacts",
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=True,
+        ),
+        tags=["contacts", "crm", "list"],
+    )
+    async def list_contacts(
+        ctx: Context,
+        query: Annotated[
+            str | None,
+            Field(description="Filter contacts by name or email (partial match). Omit to return the first per_page contacts."),
+        ] = None,
+        per_page: Annotated[
+            int,
+            Field(ge=1, le=100, description="Maximum number of contacts to return (1–100, default 15)"),
+        ] = 15,
+    ) -> ContactListResponse:
+        """Search CRM contacts by name or email.
+
+        Returns a curated list of contacts with id, email, first_name, last_name, and company.
+        When ``query`` is provided, performs a partial (LIKE) match against email, first name,
+        last name, and full name simultaneously.
+        When no contacts match, an empty list is returned — this is not an error.
+
+        Args:
+            query: Partial name or email string to filter contacts. Omit to return the first per_page contacts.
+            per_page: Maximum number of contacts to return (1–100, default 15).
+        """
+        return await _list_contacts_impl(query=query, per_page=per_page)
+
+    @mcp.resource(
+        "signnow://contacts{?query,per_page}",
+        name="list_contacts_resource",
+        description="Search CRM contacts by name or email. Use this resource before send_invite to resolve a recipient's email address by their name." + RESOURCE_PREFERRED_SUFFIX,
+        tags=["contacts", "crm", "list"],
+        mime_type="application/json",
+    )
+    async def list_contacts_resource(
+        ctx: Context,
+        query: Annotated[
+            str | None,
+            Field(description="Filter contacts by name or email (partial match). Omit to return the first per_page contacts."),
+        ] = None,
+        per_page: Annotated[
+            int,
+            Field(ge=1, le=100, description="Maximum number of contacts to return (1–100, default 15)"),
+        ] = 15,
+    ) -> ContactListResponse:
+        return await _list_contacts_impl(query=query, per_page=per_page)
 
     return

--- a/src/sn_mcp_server/tools/signnow.py
+++ b/src/sn_mcp_server/tools/signnow.py
@@ -1213,7 +1213,7 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
 
     @mcp.tool(
         name="list_contacts",
-        description="Search CRM contacts by name or email. Use this tool before send_invite to resolve a recipient's email address by their name." + TOOL_FALLBACK_SUFFIX,
+        description="Search CRM contacts by name, email, or phone. Use this tool before send_invite to resolve a recipient's email address by their name." + TOOL_FALLBACK_SUFFIX,
         annotations=ToolAnnotations(
             title="List CRM contacts",
             readOnlyHint=True,
@@ -1227,22 +1227,22 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
         ctx: Context,
         query: Annotated[
             str | None,
-            Field(description="Filter contacts by name or email (partial match). Omit to return the first per_page contacts."),
+            Field(description="Filter contacts by name, email, or phone (partial match). Omit to return the first per_page contacts."),
         ] = None,
         per_page: Annotated[
             int,
             Field(ge=1, le=100, description="Maximum number of contacts to return (1–100, default 15)"),
         ] = 15,
     ) -> ContactListResponse:
-        """Search CRM contacts by name or email.
+        """Search CRM contacts by name, email, or phone.
 
         Returns a curated list of contacts with id, email, first_name, last_name, and company.
         When ``query`` is provided, performs a partial (LIKE) match against email, first name,
-        last name, and full name simultaneously.
+        last name, full name, and phone simultaneously.
         When no contacts match, an empty list is returned — this is not an error.
 
         Args:
-            query: Partial name or email string to filter contacts. Omit to return the first per_page contacts.
+            query: Partial name, email, or phone string to filter contacts. Omit to return the first per_page contacts.
             per_page: Maximum number of contacts to return (1–100, default 15).
         """
         return await _list_contacts_impl(query=query, per_page=per_page)
@@ -1250,7 +1250,7 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
     @mcp.resource(
         "signnow://contacts{?query,per_page}",
         name="list_contacts_resource",
-        description="Search CRM contacts by name or email. Use this resource before send_invite to resolve a recipient's email address by their name." + RESOURCE_PREFERRED_SUFFIX,
+        description="Search CRM contacts by name, email, or phone. Use this resource before send_invite to resolve a recipient's email address by their name." + RESOURCE_PREFERRED_SUFFIX,
         tags=["contacts", "crm", "list"],
         mime_type="application/json",
     )
@@ -1258,7 +1258,7 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
         ctx: Context,
         query: Annotated[
             str | None,
-            Field(description="Filter contacts by name or email (partial match). Omit to return the first per_page contacts."),
+            Field(description="Filter contacts by name, email, or phone (partial match). Omit to return the first per_page contacts."),
         ] = None,
         per_page: Annotated[
             int,

--- a/tests/unit/signnow_client/test_client_other_contacts.py
+++ b/tests/unit/signnow_client/test_client_other_contacts.py
@@ -1,0 +1,194 @@
+"""Unit tests for OtherClientMixin.get_contacts method."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from signnow_client.client_other import OtherClientMixin
+from signnow_client.models.contacts import CrmContactsResponse
+
+
+class _DummyOtherClient(OtherClientMixin):
+    """Minimal dummy subclass that captures _get calls without HTTP."""
+
+    def __init__(self) -> None:
+        """Initialise captured state."""
+        self.last_get: dict | None = None
+        self._get_return: CrmContactsResponse = CrmContactsResponse(data=[])
+
+    def _get(self, url: str, headers: dict | None = None, params: dict | None = None, validate_model: object = None) -> CrmContactsResponse:
+        """Capture all _get arguments and return preset response."""
+        self.last_get = {"url": url, "headers": headers, "params": params}
+        return self._get_return
+
+
+class TestGetContactsUrl:
+    """Test that get_contacts sends requests to the correct endpoint."""
+
+    def test_calls_v2_crm_contacts_endpoint(self) -> None:
+        """Test that the correct API URL is used."""
+        client = _DummyOtherClient()
+        client.get_contacts("tok")
+        assert client.last_get["url"] == "/v2/crm/contacts"
+
+
+class TestGetContactsHeaders:
+    """Test that get_contacts sends correct request headers."""
+
+    def test_authorization_header_contains_token(self) -> None:
+        """Test Bearer token is set in Authorization header."""
+        client = _DummyOtherClient()
+        client.get_contacts("mytoken")
+        assert client.last_get["headers"]["Authorization"] == "Bearer mytoken"
+
+    def test_accept_header_is_json(self) -> None:
+        """Test Accept header requests JSON."""
+        client = _DummyOtherClient()
+        client.get_contacts("tok")
+        assert client.last_get["headers"]["Accept"] == "application/json"
+
+
+class TestGetContactsParams:
+    """Test that get_contacts constructs correct query params."""
+
+    def test_default_per_page_is_15(self) -> None:
+        """Test default per_page sent to API is 15."""
+        client = _DummyOtherClient()
+        client.get_contacts("tok")
+        assert client.last_get["params"]["per_page"] == 15
+
+    def test_page_is_always_1(self) -> None:
+        """Test page param is hardcoded to 1."""
+        client = _DummyOtherClient()
+        client.get_contacts("tok")
+        assert client.last_get["params"]["page"] == 1
+
+    def test_custom_per_page_is_forwarded(self) -> None:
+        """Test custom per_page value is forwarded in params."""
+        client = _DummyOtherClient()
+        client.get_contacts("tok", per_page=50)
+        assert client.last_get["params"]["per_page"] == 50
+
+    def test_no_filters_param_when_query_is_none(self) -> None:
+        """Test no filters key in params when query is None."""
+        client = _DummyOtherClient()
+        client.get_contacts("tok", query=None)
+        assert "filters" not in client.last_get["params"]
+
+    def test_no_filters_param_when_query_is_empty_string(self) -> None:
+        """Test no filters key in params when query is empty string."""
+        client = _DummyOtherClient()
+        client.get_contacts("tok", query="")
+        assert "filters" not in client.last_get["params"]
+
+    def test_no_filters_param_when_query_is_whitespace(self) -> None:
+        """Test no filters key in params when query is only whitespace."""
+        client = _DummyOtherClient()
+        client.get_contacts("tok", query="   ")
+        assert "filters" not in client.last_get["params"]
+
+    def test_filters_param_present_when_query_provided(self) -> None:
+        """Test filters key is present in params when query is provided."""
+        client = _DummyOtherClient()
+        client.get_contacts("tok", query="john")
+        assert "filters" in client.last_get["params"]
+
+
+class TestGetContactsFilterShape:
+    """Test that get_contacts builds the correct filter JSON."""
+
+    def _get_filter(self, query: str) -> list:
+        """Helper to get parsed filters for a given query."""
+        client = _DummyOtherClient()
+        client.get_contacts("tok", query=query)
+        return json.loads(client.last_get["params"]["filters"])
+
+    def test_filter_is_list_with_one_or_object(self) -> None:
+        """Test top-level filter is a list wrapping a single _OR object."""
+        filters = self._get_filter("john")
+        assert isinstance(filters, list)
+        assert len(filters) == 1
+        assert "_OR" in filters[0]
+
+    def test_or_contains_five_clauses(self) -> None:
+        """Test _OR combinator contains exactly 5 field clauses."""
+        filters = self._get_filter("john")
+        or_clauses = filters[0]["_OR"]
+        assert len(or_clauses) == 5
+
+    def test_query_value_passed_without_wildcards(self) -> None:
+        """Test query value is passed raw without % wrapping."""
+        filters = self._get_filter("john")
+        or_clauses = filters[0]["_OR"]
+        for clause in or_clauses:
+            field = list(clause.keys())[0]
+            if field != "_OR":
+                assert clause[field]["value"] == "john"
+
+    def test_email_clause_uses_like_type(self) -> None:
+        """Test email filter clause uses 'like' type."""
+        filters = self._get_filter("john")
+        or_clauses = filters[0]["_OR"]
+        email_clause = next(c for c in or_clauses if "email" in c)
+        assert email_clause["email"]["type"] == "like"
+        assert email_clause["email"]["value"] == "john"
+
+    def test_first_name_clause_present(self) -> None:
+        """Test first_name filter clause is present."""
+        filters = self._get_filter("john")
+        or_clauses = filters[0]["_OR"]
+        assert any("first_name" in c for c in or_clauses)
+
+    def test_last_name_clause_present(self) -> None:
+        """Test last_name filter clause is present."""
+        filters = self._get_filter("john")
+        or_clauses = filters[0]["_OR"]
+        assert any("last_name" in c for c in or_clauses)
+
+    def test_full_name_clause_present(self) -> None:
+        """Test full_name filter clause is present."""
+        filters = self._get_filter("john")
+        or_clauses = filters[0]["_OR"]
+        assert any("full_name" in c for c in or_clauses)
+
+    def test_phone_clause_present(self) -> None:
+        """Test phone filter clause is present."""
+        filters = self._get_filter("john")
+        or_clauses = filters[0]["_OR"]
+        assert any("phone" in c for c in or_clauses)
+
+    def test_query_whitespace_is_stripped(self) -> None:
+        """Test surrounding whitespace is stripped from query before building filter."""
+        client = _DummyOtherClient()
+        client.get_contacts("tok", query="  john  ")
+        filters = json.loads(client.last_get["params"]["filters"])
+        or_clauses = filters[0]["_OR"]
+        email_clause = next(c for c in or_clauses if "email" in c)
+        assert email_clause["email"]["value"] == "john"
+
+    @pytest.mark.parametrize("field", ["first_name", "last_name", "full_name", "phone"])
+    def test_field_clause_value_matches_query(self, field: str) -> None:
+        """Test each field clause carries the stripped query value."""
+        filters = self._get_filter("kucher")
+        or_clauses = filters[0]["_OR"]
+        clause = next(c for c in or_clauses if field in c)
+        assert clause[field]["value"] == "kucher"
+        assert clause[field]["type"] == "like"
+
+
+class TestGetContactsReturnType:
+    """Test that get_contacts returns the validated model."""
+
+    def test_returns_crm_contacts_response(self) -> None:
+        """Test return value is a CrmContactsResponse instance."""
+        client = _DummyOtherClient()
+        result = client.get_contacts("tok")
+        assert isinstance(result, CrmContactsResponse)
+
+    def test_returns_empty_data_when_no_contacts(self) -> None:
+        """Test empty data list is returned when API has no contacts."""
+        client = _DummyOtherClient()
+        result = client.get_contacts("tok")
+        assert result.data == []

--- a/tests/unit/sn_mcp_server/tools/test_list_contacts.py
+++ b/tests/unit/sn_mcp_server/tools/test_list_contacts.py
@@ -1,0 +1,176 @@
+"""Unit tests for list_contacts module."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from signnow_client.exceptions import SignNowAPIAuthenticationError
+from signnow_client.models.contacts import CrmContact, CrmContactCompany, CrmContactsResponse
+from sn_mcp_server.tools.list_contacts import _list_contacts
+from sn_mcp_server.tools.models import ContactItem, ContactListResponse
+
+
+class TestListContacts:
+    """Test cases for _list_contacts."""
+
+    @pytest.fixture
+    def mock_client(self) -> MagicMock:
+        """Create a mock SignNowAPIClient."""
+        return MagicMock()
+
+    @pytest.fixture
+    def contact_with_company(self) -> CrmContact:
+        """Create a CrmContact with all fields populated."""
+        return CrmContact(
+            id="contact-123",
+            email="john.doe@example.com",
+            first_name="John",
+            last_name="Doe",
+            company=CrmContactCompany(name="Acme Corp"),
+        )
+
+    @pytest.fixture
+    def contact_minimal(self) -> CrmContact:
+        """Create a CrmContact with only required fields."""
+        return CrmContact(
+            id="contact-456",
+            email="minimal@example.com",
+        )
+
+    async def test_returns_curated_contact_list(self, mock_client: MagicMock, contact_with_company: CrmContact) -> None:
+        """Test that contacts are curated into ContactListResponse."""
+        mock_client.get_contacts.return_value = CrmContactsResponse(data=[contact_with_company])
+
+        result = await _list_contacts("tok", mock_client)
+
+        assert isinstance(result, ContactListResponse)
+        assert result.count == 1
+        assert len(result.contacts) == 1
+
+    async def test_contact_fields_are_curated(self, mock_client: MagicMock, contact_with_company: CrmContact) -> None:
+        """Test each curated field is correctly mapped from API model."""
+        mock_client.get_contacts.return_value = CrmContactsResponse(data=[contact_with_company])
+
+        result = await _list_contacts("tok", mock_client)
+
+        item = result.contacts[0]
+        assert isinstance(item, ContactItem)
+        assert item.id == "contact-123"
+        assert item.email == "john.doe@example.com"
+        assert item.first_name == "John"
+        assert item.last_name == "Doe"
+        assert item.company == "Acme Corp"
+
+    async def test_company_is_none_when_absent(self, mock_client: MagicMock, contact_minimal: CrmContact) -> None:
+        """Test that company is None when contact has no company."""
+        mock_client.get_contacts.return_value = CrmContactsResponse(data=[contact_minimal])
+
+        result = await _list_contacts("tok", mock_client)
+
+        assert result.contacts[0].company is None
+
+    async def test_optional_name_fields_are_none(self, mock_client: MagicMock, contact_minimal: CrmContact) -> None:
+        """Test that first_name and last_name are None when absent on contact."""
+        mock_client.get_contacts.return_value = CrmContactsResponse(data=[contact_minimal])
+
+        result = await _list_contacts("tok", mock_client)
+
+        item = result.contacts[0]
+        assert item.first_name is None
+        assert item.last_name is None
+
+    async def test_empty_data_returns_empty_list(self, mock_client: MagicMock) -> None:
+        """Test that empty API data returns ContactListResponse with zero count."""
+        mock_client.get_contacts.return_value = CrmContactsResponse(data=[])
+
+        result = await _list_contacts("tok", mock_client)
+
+        assert result.count == 0
+        assert result.contacts == []
+
+    async def test_count_matches_contacts_length(
+        self,
+        mock_client: MagicMock,
+        contact_with_company: CrmContact,
+        contact_minimal: CrmContact,
+    ) -> None:
+        """Test that count always equals the number of contact items."""
+        mock_client.get_contacts.return_value = CrmContactsResponse(data=[contact_with_company, contact_minimal])
+
+        result = await _list_contacts("tok", mock_client)
+
+        assert result.count == 2
+        assert len(result.contacts) == result.count
+
+    async def test_passes_query_to_client(self, mock_client: MagicMock) -> None:
+        """Test that query parameter is forwarded to client.get_contacts."""
+        mock_client.get_contacts.return_value = CrmContactsResponse(data=[])
+
+        await _list_contacts("tok", mock_client, query="john")
+
+        mock_client.get_contacts.assert_called_once_with("tok", query="john", per_page=15)
+
+    async def test_passes_per_page_to_client(self, mock_client: MagicMock) -> None:
+        """Test that per_page parameter is forwarded to client.get_contacts."""
+        mock_client.get_contacts.return_value = CrmContactsResponse(data=[])
+
+        await _list_contacts("tok", mock_client, per_page=50)
+
+        mock_client.get_contacts.assert_called_once_with("tok", query=None, per_page=50)
+
+    async def test_default_parameters_passed_to_client(self, mock_client: MagicMock) -> None:
+        """Test that default query=None and per_page=15 are forwarded."""
+        mock_client.get_contacts.return_value = CrmContactsResponse(data=[])
+
+        await _list_contacts("tok", mock_client)
+
+        mock_client.get_contacts.assert_called_once_with("tok", query=None, per_page=15)
+
+    async def test_per_page_zero_raises_value_error(self, mock_client: MagicMock) -> None:
+        """Test that per_page=0 raises ValueError before calling the API."""
+        with pytest.raises(ValueError, match="per_page must be between 1 and 100"):
+            await _list_contacts("tok", mock_client, per_page=0)
+
+        mock_client.get_contacts.assert_not_called()
+
+    async def test_per_page_101_raises_value_error(self, mock_client: MagicMock) -> None:
+        """Test that per_page=101 raises ValueError before calling the API."""
+        with pytest.raises(ValueError, match="per_page must be between 1 and 100"):
+            await _list_contacts("tok", mock_client, per_page=101)
+
+        mock_client.get_contacts.assert_not_called()
+
+    async def test_per_page_negative_raises_value_error(self, mock_client: MagicMock) -> None:
+        """Test that negative per_page raises ValueError."""
+        with pytest.raises(ValueError, match="per_page must be between 1 and 100"):
+            await _list_contacts("tok", mock_client, per_page=-5)
+
+        mock_client.get_contacts.assert_not_called()
+
+    @pytest.mark.parametrize("per_page", [1, 15, 50, 100])
+    async def test_per_page_boundary_values_are_accepted(self, mock_client: MagicMock, per_page: int) -> None:
+        """Test that boundary per_page values 1 and 100 are accepted."""
+        mock_client.get_contacts.return_value = CrmContactsResponse(data=[])
+
+        result = await _list_contacts("tok", mock_client, per_page=per_page)
+
+        assert result.count == 0
+        mock_client.get_contacts.assert_called_once()
+
+    async def test_auth_error_propagates(self, mock_client: MagicMock) -> None:
+        """Test that SignNowAPIAuthenticationError propagates from client."""
+        mock_client.get_contacts.side_effect = SignNowAPIAuthenticationError("invalid token")
+
+        with pytest.raises(SignNowAPIAuthenticationError):
+            await _list_contacts("bad-tok", mock_client)
+
+    async def test_token_is_passed_to_client(self, mock_client: MagicMock) -> None:
+        """Test that the access token is forwarded correctly to client."""
+        mock_client.get_contacts.return_value = CrmContactsResponse(data=[])
+
+        await _list_contacts("my-secret-token", mock_client)
+
+        call_args = mock_client.get_contacts.call_args
+        assert call_args[0][0] == "my-secret-token"


### PR DESCRIPTION
## Summary

Implements the `list_contacts` MCP tool and resource that searches SignNow CRM contacts. 

## Changes

- **`src/signnow_client/models/contacts.py`** — New Pydantic models: `CrmContactPhone`, `CrmContactCompany`, `CrmContact`, `CrmContactsResponse`
- **`src/signnow_client/models/__init__.py`** — Export new contact models
- **`src/signnow_client/client_other.py`** — `get_contacts()` method: `GET /v2/crm/contacts` with correct `_OR` filter JSON (email, first_name, last_name, full_name, phone)
- **`src/sn_mcp_server/tools/list_contacts.py`** — `_list_contacts()` business logic: curates API response into `ContactListResponse`, validates `per_page` 1–100
- **`src/sn_mcp_server/tools/models.py`** — `ContactItem` and `ContactListResponse` curated response models
- **`src/sn_mcp_server/tools/signnow.py`** — Registers `list_contacts` tool and `list_contacts_resource` MCP resource

## Tests

- **`tests/unit/sn_mcp_server/tools/test_list_contacts.py`** — 18 unit tests for `_list_contacts`: field curation, optional fields, `per_page` validation (boundaries, out-of-range), query/per_page forwarding, auth error propagation
- **`tests/unit/signnow_client/test_client_other_contacts.py`** — 25 unit tests for `get_contacts`: URL, headers, params, filter JSON shape (5 clauses, raw value, each field present, whitespace stripping, parametrized per field)