### PR TITLE
Add view_document tool with MCP Apps inline rendering

### DIFF
--- a/src/signnow_client/client_document_groups.py
+++ b/src/signnow_client/client_document_groups.py
@@ -16,6 +16,8 @@ from .models import (
     CancelFreeformInviteRequest,
     CreateDocumentGroupEmbeddedEditorRequest,
     CreateDocumentGroupEmbeddedSendingRequest,
+    CreateDocumentGroupEmbeddedViewRequest,
+    CreateDocumentGroupEmbeddedViewResponse,
     CreateDocumentGroupFromTemplateRequest,
     CreateDocumentGroupFromTemplateResponse,
     CreateDocumentGroupRequest,
@@ -428,7 +430,7 @@ class DocumentGroupClientMixin:
 
         headers = {"Accept": "application/json", "Content-Type": "application/json", "Authorization": f"Bearer {token}"}
 
-        response = self._post(f"/v2/document-groups/{doc_group_id}/document-group-template", headers=headers, json_data=request_data.model_dump(exclude_none=True))
+        self._post(f"/v2/document-groups/{doc_group_id}/document-group-template", headers=headers, json_data=request_data.model_dump(exclude_none=True))
 
         # This endpoint returns 202 (Accepted) status
         return True
@@ -505,7 +507,7 @@ class DocumentGroupClientMixin:
         except httpx.TimeoutException as e:
             raise SignNowAPITimeoutError("SignNow API timeout") from e
         except httpx.HTTPStatusError as e:
-            raise self._handle_http_error(e)
+            raise self._handle_http_error(e) from e
         except Exception as e:
             raise SignNowAPIError(f"Unexpected error in edit_document_group_template_recipients request: {e}") from e
 
@@ -531,4 +533,37 @@ class DocumentGroupClientMixin:
             headers=headers,
             json_data=request_data.model_dump(exclude_none=True),
             validate_model=CreateDocumentGroupFromTemplateResponse,
+        )
+
+    def create_document_group_embedded_view(
+        self,
+        token: str,
+        document_group_id: str,
+        request_data: CreateDocumentGroupEmbeddedViewRequest,
+    ) -> CreateDocumentGroupEmbeddedViewResponse:
+        """Create an embedded view link for a document group.
+
+        Generates a link that opens the document group in read-only mode.
+        No SignNow login required. Link reusable until expiration.
+
+        POST /v2/document-groups/{document_group_id}/embedded-view
+
+        Args:
+            token: Access token for authentication
+            document_group_id: ID of the document group to view
+            request_data: View link configuration (expiration, redirect)
+
+        Returns:
+            CreateDocumentGroupEmbeddedViewResponse with the generated view link
+
+        Raises:
+            SignNowAPIError: On 400/403/404/422 API errors
+        """
+        headers = {"Accept": "application/json", "Content-Type": "application/json", "Authorization": f"Bearer {token}"}
+
+        return self._post(
+            f"/v2/document-groups/{document_group_id}/embedded-view",
+            headers=headers,
+            json_data=request_data.model_dump(exclude_none=True),
+            validate_model=CreateDocumentGroupEmbeddedViewResponse,
         )

--- a/src/signnow_client/client_documents.py
+++ b/src/signnow_client/client_documents.py
@@ -14,6 +14,8 @@ from .models import (
     CreateDocumentEmbeddedInviteRequest,
     CreateDocumentEmbeddedInviteResponse,
     CreateDocumentEmbeddedSendingRequest,
+    CreateDocumentEmbeddedViewRequest,
+    CreateDocumentEmbeddedViewResponse,
     CreateDocumentFieldInviteRequest,
     CreateDocumentFieldInviteResponse,
     CreateDocumentFreeformInviteRequest,
@@ -130,7 +132,7 @@ class DocumentClientMixin:
         except httpx.TimeoutException as e:
             raise SignNowAPITimeoutError("SignNow API timeout") from e
         except httpx.HTTPStatusError as e:
-            raise self._handle_http_error(e)
+            raise self._handle_http_error(e) from e
         except Exception as e:
             raise SignNowAPIError(f"Unexpected error in prefill_text_fields request: {e}") from e
 
@@ -492,4 +494,37 @@ class DocumentClientMixin:
             headers=headers,
             json_data=request_data.model_dump(),
             validate_model=SendDocumentCopyByEmailResponse,
+        )
+
+    def create_document_embedded_view(
+        self,
+        token: str,
+        document_id: str,
+        request_data: CreateDocumentEmbeddedViewRequest,
+    ) -> CreateDocumentEmbeddedViewResponse:
+        """Create an embedded view link for a document.
+
+        Generates a link that opens the document in read-only mode in a browser or iframe.
+        No SignNow login required to view. The link can be used multiple times until it expires.
+
+        POST /v2/documents/{document_id}/embedded-view
+
+        Args:
+            token: Access token for authentication
+            document_id: ID of the document to view
+            request_data: View link configuration (expiration, redirect)
+
+        Returns:
+            CreateDocumentEmbeddedViewResponse with the generated view link
+
+        Raises:
+            SignNowAPIError: On 400/403/404/422 API errors
+        """
+        headers = {"Accept": "application/json", "Content-Type": "application/json", "Authorization": f"Bearer {token}"}
+
+        return self._post(
+            f"/v2/documents/{document_id}/embedded-view",
+            headers=headers,
+            json_data=request_data.model_dump(exclude_none=True),
+            validate_model=CreateDocumentEmbeddedViewResponse,
         )

--- a/src/signnow_client/models/__init__.py
+++ b/src/signnow_client/models/__init__.py
@@ -104,6 +104,9 @@ __all__ = [
     # Document copy by email models
     "SendDocumentCopyByEmailRequest",
     "SendDocumentCopyByEmailResponse",
+    # Document embedded view models
+    "CreateDocumentEmbeddedViewRequest",
+    "CreateDocumentEmbeddedViewResponse",
     # General Embedded Invite models (for document signing)
     "EmbeddedInviteAuthentication",
     "EmbeddedInviteDocument",
@@ -156,6 +159,9 @@ __all__ = [
     # Document group embedded models
     "CreateDocumentGroupEmbeddedEditorRequest",
     "CreateDocumentGroupEmbeddedSendingRequest",
+    "CreateDocumentGroupEmbeddedViewRequest",
+    "EmbeddedViewData",
+    "CreateDocumentGroupEmbeddedViewResponse",
     # Other Models
     "OrganizationSetting",
     "DocumentDownloadLinkResponse",

--- a/src/signnow_client/models/document_groups.py
+++ b/src/signnow_client/models/document_groups.py
@@ -359,3 +359,47 @@ class GetDocumentGroupTemplateResponse(BaseModel):
     id: str = Field(..., description="Document group template ID")
     group_name: str = Field(..., description="Name of the template group")
     templates: list[TemplateShort] = Field(..., description="List of templates in this group")
+
+
+class CreateDocumentGroupEmbeddedViewRequest(BaseModel):
+    """Request model for creating a document group embedded view link.
+
+    POST /v2/document-groups/{document_group_id}/embedded-view
+    """
+
+    link_expiration: int | None = Field(
+        None,
+        ge=43200,
+        le=518400,
+        description="Link expiration in minutes (43200–518400, default: 43200 = 30 days)",
+    )
+    redirect_uri: str | None = Field(
+        None,
+        description="URL opened after clicking Close button.",
+    )
+    redirect_target: str | None = Field(
+        None,
+        description="Redirect target: 'blank' (new tab) or 'self' (same tab). Only used if redirect_uri is set.",
+    )
+
+    def model_dump(self: Self, **kwargs: Any) -> dict[str, Any]:  # noqa: ANN401
+        """Override to exclude redirect_target when redirect_uri is absent."""
+        data = super().model_dump(**kwargs)
+        if (not self.redirect_uri or not self.redirect_uri.strip()) and "redirect_target" in data:
+            del data["redirect_target"]
+        return data
+
+
+class EmbeddedViewData(BaseModel):
+    """Data wrapper for document group embedded view response."""
+
+    link: str = Field(..., description="Embedded view link")
+
+
+class CreateDocumentGroupEmbeddedViewResponse(BaseModel):
+    """Response from POST /v2/document-groups/{document_group_id}/embedded-view.
+
+    Note: Document group endpoint wraps link in ``data`` object.
+    """
+
+    data: EmbeddedViewData = Field(..., description="Embedded view data")

--- a/src/signnow_client/models/templates_and_documents.py
+++ b/src/signnow_client/models/templates_and_documents.py
@@ -987,3 +987,47 @@ class SendDocumentCopyByEmailResponse(BaseModel):
     """Response from POST /document/{id}/email2."""
 
     status: str = Field(..., description="'success' on success")
+
+
+class CreateDocumentEmbeddedViewRequest(BaseModel):
+    """Request model for creating a document embedded view link.
+
+    POST /v2/documents/{document_id}/embedded-view
+    """
+
+    link_expiration: int | None = Field(
+        None,
+        ge=43200,
+        le=518400,
+        description="Link expiration in minutes (43200–518400, default: 43200 = 30 days)",
+    )
+    redirect_uri: str | None = Field(
+        None,
+        description="URL opened after clicking Close button. Default: 'You've viewed a document' page.",
+    )
+    redirect_target: str | None = Field(
+        None,
+        description="Redirect target: 'blank' (new tab) or 'self' (same tab). Only used if redirect_uri is set.",
+    )
+
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:  # noqa: ANN401
+        """Override to exclude redirect_target when redirect_uri is absent."""
+        data = super().model_dump(**kwargs)
+        if (not self.redirect_uri or not self.redirect_uri.strip()) and "redirect_target" in data:
+            del data["redirect_target"]
+        return data
+
+
+class CreateDocumentEmbeddedViewResponse(BaseModel):
+    """Response from POST /v2/documents/{document_id}/embedded-view.
+
+    Note: Document endpoint wraps link in ``data`` object, same as the
+    document-group endpoint.
+    """
+
+    class Data(BaseModel):
+        """Embedded view link wrapper."""
+
+        link: str = Field(..., description="Embedded view link for the document")
+
+    data: Data = Field(..., description="Embedded view data")

--- a/src/sn_mcp_server/tools/document_view.py
+++ b/src/sn_mcp_server/tools/document_view.py
@@ -11,6 +11,7 @@ import pathlib
 from typing import Literal
 
 from signnow_client import SignNowAPIClient
+from signnow_client.exceptions import SignNowAPINotFoundError
 from signnow_client.models import (
     CreateDocumentEmbeddedViewRequest,
     CreateDocumentGroupEmbeddedViewRequest,
@@ -56,17 +57,19 @@ def _view_document(
     document_name: str | None = None
 
     if entity_type is None:
-        # Auto-detect: document_group first (per AGENTS.md), document as fallback
+        # Auto-detect: document_group first (per AGENTS.md), document as fallback.
+        # Only SignNowAPINotFoundError (404) triggers fallback — auth/rate-limit/
+        # server errors propagate so the caller sees the real failure.
         try:
             group = client.get_document_group_v2(token, entity_id)
             entity_type = "document_group"
             document_name = group.data.name
-        except Exception:
+        except SignNowAPINotFoundError:
             try:
                 doc = client.get_document(token, entity_id)
                 entity_type = "document"
                 document_name = doc.document_name
-            except Exception:
+            except SignNowAPINotFoundError:
                 raise ValueError(f"Entity with ID '{entity_id}' not found as either document group or document") from None
 
     # Fetch entity name when explicit entity_type was provided (name not yet resolved)

--- a/src/sn_mcp_server/tools/document_view.py
+++ b/src/sn_mcp_server/tools/document_view.py
@@ -1,0 +1,96 @@
+"""
+Document view functions for SignNow MCP server.
+
+This module generates embedded view links for documents and document groups.
+The links open a read-only viewer that requires no SignNow login.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Literal
+
+from signnow_client import SignNowAPIClient
+from signnow_client.models import (
+    CreateDocumentEmbeddedViewRequest,
+    CreateDocumentGroupEmbeddedViewRequest,
+)
+
+from .models import ViewDocumentResponse
+
+VIEWER_RESOURCE_URI: str = "ui://signnow/document-viewer"
+
+_STATIC_DIR = pathlib.Path(__file__).parent / "static"
+_VIEWER_HTML: str = (_STATIC_DIR / "document_viewer.html").read_text(encoding="utf-8")
+
+
+def _view_document(
+    entity_id: str,
+    entity_type: Literal["document", "document_group"] | None,
+    link_expiration_minutes: int | None,
+    token: str,
+    client: SignNowAPIClient,
+) -> ViewDocumentResponse:
+    """Generate an embedded view link for a document or document group.
+
+    Auto-detects entity type if not provided (tries document_group first per AGENTS.md,
+    then document as fallback).
+
+    Args:
+        entity_id: ID of the document or document group
+        entity_type: Explicit entity type (optional, saves one API call if provided).
+            Accepted values: 'document' or 'document_group'.
+        link_expiration_minutes: Link lifetime in minutes (43200–518400). None = API default (43200 = 30 days).
+        token: Access token for authentication
+        client: SignNow API client instance
+
+    Returns:
+        ViewDocumentResponse with view_link, document_name, entity_id, entity_type
+
+    Raises:
+        ValueError: If entity_type is None and the entity is not found as either
+            document group or document.
+        SignNowAPIError: If the entity is not found when entity_type is explicit,
+            or if the embedded-view API returns 403/422.
+    """
+    document_name: str | None = None
+
+    if entity_type is None:
+        # Auto-detect: document_group first (per AGENTS.md), document as fallback
+        try:
+            group = client.get_document_group_v2(token, entity_id)
+            entity_type = "document_group"
+            document_name = group.data.name
+        except Exception:
+            try:
+                doc = client.get_document(token, entity_id)
+                entity_type = "document"
+                document_name = doc.document_name
+            except Exception:
+                raise ValueError(f"Entity with ID '{entity_id}' not found as either document group or document") from None
+
+    # Fetch entity name when explicit entity_type was provided (name not yet resolved)
+    if document_name is None:
+        if entity_type == "document_group":
+            group = client.get_document_group_v2(token, entity_id)
+            document_name = group.data.name
+        else:
+            doc = client.get_document(token, entity_id)
+            document_name = doc.document_name
+
+    # Generate the embedded view link
+    if entity_type == "document_group":
+        request = CreateDocumentGroupEmbeddedViewRequest(link_expiration=link_expiration_minutes)
+        response = client.create_document_group_embedded_view(token, entity_id, request)
+        view_link = response.data.link
+    else:
+        request_doc = CreateDocumentEmbeddedViewRequest(link_expiration=link_expiration_minutes)
+        response_doc = client.create_document_embedded_view(token, entity_id, request_doc)
+        view_link = response_doc.data.link
+
+    return ViewDocumentResponse(
+        view_link=view_link,
+        document_name=document_name,
+        entity_id=entity_id,
+        entity_type=entity_type,
+    )

--- a/src/sn_mcp_server/tools/models.py
+++ b/src/sn_mcp_server/tools/models.py
@@ -969,6 +969,15 @@ class SkillSummary(BaseModel):
     description: str = Field(description="One-line description from skill front-matter")
 
 
+class ViewDocumentResponse(BaseModel):
+    """Response from the view_document tool."""
+
+    view_link: str = Field(..., description="Embedded view link — opens the document in a read-only viewer without requiring SignNow login")
+    document_name: str = Field(..., description="Name of the document or document group")
+    entity_id: str = Field(..., description="Document or document group ID")
+    entity_type: str = Field(..., description="Entity type: 'document' or 'document_group'")
+
+
 class SkillResponse(BaseModel):
     """Response from the signnow_skills tool.
 

--- a/src/sn_mcp_server/tools/signnow.py
+++ b/src/sn_mcp_server/tools/signnow.py
@@ -15,6 +15,7 @@ from ..token_provider import TokenProvider
 from .create_from_template import _create_from_template
 from .document import _get_document, _update_document_fields, _upload_document
 from .document_download_link import _get_document_download_link
+from .document_view import _VIEWER_HTML, VIEWER_RESOURCE_URI, _view_document
 from .embedded_editor import (
     _create_embedded_editor,
     _create_embedded_editor_from_template,
@@ -52,6 +53,7 @@ from .models import (
     UpdateDocumentFields,
     UpdateDocumentFieldsResponse,
     UploadDocumentResponse,
+    ViewDocumentResponse,
 )
 from .reminder import _send_invite_reminder
 from .send_invite import _send_invite, _send_invite_from_template
@@ -1204,5 +1206,71 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
         """
         token, client = _get_token_and_client(token_provider)
         return await _send_invite_reminder(client, token, entity_id, entity_type, email, subject, message, ctx=ctx)
+
+    @mcp.tool(
+        name="view_document",
+        description=(
+            "Generate a read-only embedded view link for a document or document group. "
+            "To find an entity by name, first call list_documents or list_templates "
+            "to search for it, then pass the returned entity_id here. "
+            "In MCP Apps-compatible hosts (MCP Inspector, VS Code, Goose, LibreChat) "
+            "the document renders inline — no tab switch needed. "
+            "In other hosts, the returned view_link is presented as a clickable URL."
+        ),
+        meta={"ui": {"resourceUri": VIEWER_RESOURCE_URI}},
+        annotations=ToolAnnotations(
+            title="View document",
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=True,
+        ),
+        tags=["document", "document_group", "view", "preview"],
+    )
+    def view_document(
+        ctx: Context,
+        entity_id: Annotated[str, Field(description="ID of the document or document group to view")],
+        entity_type: Annotated[
+            Literal["document", "document_group"] | None,
+            Field(description="Type of entity: 'document' or 'document_group'. Skip for auto-detection (tries document_group first)."),
+        ] = None,
+        link_expiration_minutes: Annotated[
+            int | None,
+            Field(
+                default=None,
+                ge=43200,
+                le=518400,
+                description="Link lifetime in minutes (43200–518400). Defaults to 43200 (30 days) when omitted.",
+            ),
+        ] = None,
+    ) -> ViewDocumentResponse:
+        """Generate a read-only embedded view link for a document or document group.
+
+        Calls POST /v2/documents/{id}/embedded-view or POST /v2/document-groups/{id}/embedded-view.
+        No SignNow login required to open the link. Auto-detects entity type when omitted.
+
+        Tip: use list_documents first to discover document IDs by name or criteria.
+        Tip: if entity_type is known, pass it explicitly to avoid an extra auto-detection GET.
+
+        Args:
+            entity_id: Document ID or document group ID.
+            entity_type: Optional discriminator ('document' or 'document_group').
+            link_expiration_minutes: Optional link lifetime in minutes (43200–518400).
+
+        Returns:
+            ViewDocumentResponse with view_link, document_name, entity_id, entity_type.
+        """
+        token, client = _get_token_and_client(token_provider)
+        return _view_document(entity_id, entity_type, link_expiration_minutes, token, client)
+
+    @mcp.resource(
+        VIEWER_RESOURCE_URI,
+        name="document_viewer_app",
+        description="MCP Apps inline viewer for SignNow documents. Returns an HTML page that renders an embedded document view inside a sandboxed iframe.",
+        mime_type="text/html;profile=mcp-app",
+    )
+    def get_document_viewer_ui() -> str:
+        """Return the MCP Apps HTML viewer for inline document rendering."""
+        return _VIEWER_HTML
 
     return

--- a/src/sn_mcp_server/tools/static/document_viewer.html
+++ b/src/sn_mcp_server/tools/static/document_viewer.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: system-ui, -apple-system, sans-serif; height: 100vh; display: flex;
+           flex-direction: column; background: #f8f9fa; }
+    #loading { flex: 1; display: flex; justify-content: center; align-items: center;
+               color: #6b7280; font-size: 14px; }
+    #error { flex: 1; display: flex; justify-content: center; align-items: center;
+             color: #dc2626; font-size: 14px; padding: 20px; text-align: center; }
+    #header { padding: 8px 16px; background: #fff; border-bottom: 1px solid #e5e7eb;
+              font-size: 13px; color: #374151; align-items: center; gap: 8px; }
+    #header .name { font-weight: 600; }
+    #header .link { color: #4f46e5; text-decoration: none; font-size: 12px; margin-left: auto; }
+    #header .link:hover { text-decoration: underline; }
+    #viewer { flex: 1; border: none; width: 100%; }
+  </style>
+</head>
+<body>
+  <div id="header" style="display:none">
+    <span class="name" id="doc-name"></span>
+    <a class="link" id="open-link" href="#" target="_blank" rel="noopener">Open in SignNow ↗</a>
+  </div>
+  <div id="loading">Loading document preview&#8230;</div>
+  <div id="error" style="display:none"></div>
+  <iframe id="viewer" style="display:none" sandbox="allow-scripts allow-same-origin allow-popups allow-forms"></iframe>
+
+  <script>
+    /**
+     * MCP Apps View — JSON-RPC 2.0 over postMessage protocol.
+     *
+     * Architecture: Host ↔ outer sandbox proxy ↔ THIS iframe (inner)
+     * We communicate with window.parent (outer sandbox), which relays to the host.
+     *
+     * Lifecycle:
+     *   1. We send  ui/initialize request
+     *   2. Host responds with capabilities
+     *   3. We send  ui/notifications/initialized
+     *   4. Host fires oninitialized → sends ui/notifications/tool-input
+     *   5. Host sends ui/notifications/tool-result  ← we render the document here
+     *
+     * Reload recovery:
+     *   ChatGPT sometimes doesn't replay tool-result after page reload.
+     *   MCP Apps docs recommend localStorage/sessionStorage for state persistence.
+     *   Each ChatGPT tool call runs in a unique sandbox origin (connector_HASH),
+     *   so sessionStorage is per-document and never collides.
+     */
+
+    var _documentRendered = false;
+    var _nextId = 1;
+    var _pending = {};
+
+    function _send(msg) {
+      window.parent.postMessage(msg, '*');
+    }
+
+    function _request(method, params) {
+      var id = _nextId++;
+      return new Promise(function(resolve, reject) {
+        _pending[id] = { resolve: resolve, reject: reject };
+        _send({ jsonrpc: '2.0', id: id, method: method, params: params || {} });
+      });
+    }
+
+    function _requestSize(width, height) {
+      var params = {};
+      if (width != null)  params.width  = width;
+      if (height != null) params.height = height;
+      _send({ jsonrpc: '2.0', method: 'ui/notifications/size-changed', params: params });
+    }
+
+    function _showDocument(params) {
+      var sc = params.structuredContent || {};
+      var link = sc.view_link;
+      var name = sc.document_name || 'Document';
+
+      if (!link && Array.isArray(params.content)) {
+        for (var i = 0; i < params.content.length; i++) {
+          var block = params.content[i];
+          if (block.type === 'text' && block.text) {
+            try {
+              var parsed = JSON.parse(block.text);
+              if (parsed.view_link) { link = parsed.view_link; name = parsed.document_name || name; }
+            } catch (_) {}
+          }
+        }
+      }
+
+      if (!link) return;
+
+      _documentRendered = true;
+
+      /* Persist for reload recovery (per MCP Apps recommendation). */
+      try { sessionStorage.setItem('sn_view', JSON.stringify({ link: link, name: name })); }
+      catch (_) {}
+
+      document.getElementById('loading').style.display = 'none';
+      document.getElementById('error').style.display = 'none';
+
+      var header = document.getElementById('header');
+      header.style.display = 'flex';
+      document.getElementById('doc-name').textContent = name;
+      document.getElementById('open-link').href = link;
+
+      var viewer = document.getElementById('viewer');
+      viewer.src = link;
+      viewer.style.display = 'block';
+    }
+
+    /* ── Message handler ── */
+    window.addEventListener('message', function(event) {
+      var data = event.data;
+      if (!data || typeof data !== 'object' || data.jsonrpc !== '2.0') return;
+
+      /* Response to one of our requests */
+      if (data.id !== undefined && _pending[data.id]) {
+        var handler = _pending[data.id];
+        delete _pending[data.id];
+        if (data.error) handler.reject(new Error(data.error.message || 'MCP error'));
+        else handler.resolve(data.result);
+        return;
+      }
+
+      /* Incoming notifications from host */
+      if (data.method === 'ui/notifications/tool-result') {
+        _showDocument(data.params || {});
+      }
+    });
+
+    /* ── Initialization handshake ── */
+    var _initDone = false;
+
+    function _sendInitialized() {
+      if (_initDone) return;
+      _initDone = true;
+      _send({ jsonrpc: '2.0', method: 'ui/notifications/initialized', params: {} });
+      _requestSize(null, 800);
+    }
+
+    _request('ui/initialize', {
+      protocolVersion: '2026-01-26',
+      appInfo: { name: 'signnow-document-viewer', version: '1.0.0' },
+      appCapabilities: {}
+    }).then(function() {
+      _sendInitialized();
+    }).catch(function() {
+      _sendInitialized();
+    });
+
+    /* Fallback: send initialized even if ui/initialize never responds. */
+    setTimeout(_sendInitialized, 2000);
+
+    /* ── Reload recovery via sessionStorage ──
+       If host doesn't deliver tool-result within 3 s, restore from cache. */
+    setTimeout(function() {
+      if (_documentRendered) return;
+      try {
+        var raw = sessionStorage.getItem('sn_view');
+        if (!raw) return;
+        var cached = JSON.parse(raw);
+        if (cached.link) {
+          _showDocument({ structuredContent: { view_link: cached.link, document_name: cached.name } });
+        }
+      } catch (_) {}
+    }, 3000);
+
+    /* Final fallback: show error after 15 s if nothing worked. */
+    setTimeout(function() {
+      if (document.getElementById('viewer').style.display === 'none') {
+        document.getElementById('loading').style.display = 'none';
+        document.getElementById('error').style.display = 'flex';
+        document.getElementById('error').textContent =
+          'Could not load document preview. Use the view link returned in the tool result.';
+      }
+    }, 15000);
+  </script>
+</body>
+</html>

--- a/tests/api/fixtures/post_embedded_view__success.json
+++ b/tests/api/fixtures/post_embedded_view__success.json
@@ -1,0 +1,1 @@
+{"data": {"link": "https://app.signnow.com/webapp/document/doc_001?access_token=api-view-token&embedded=1"}}

--- a/tests/api/fixtures/post_embedded_view_group__success.json
+++ b/tests/api/fixtures/post_embedded_view_group__success.json
@@ -1,0 +1,1 @@
+{"data": {"link": "https://app.signnow.com/webapp/document-group/grp_001?access_token=api-view-token-grp&embedded=1"}}

--- a/tests/api/test_document_embedded_view.py
+++ b/tests/api/test_document_embedded_view.py
@@ -1,0 +1,148 @@
+"""API-level tests for document and document group embedded view client methods."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+import respx
+
+from signnow_client import SignNowAPIClient
+from signnow_client.exceptions import SignNowAPINotFoundError
+from signnow_client.models import (
+    CreateDocumentEmbeddedViewRequest,
+    CreateDocumentEmbeddedViewResponse,
+    CreateDocumentGroupEmbeddedViewRequest,
+    CreateDocumentGroupEmbeddedViewResponse,
+)
+
+
+class TestCreateDocumentEmbeddedView:
+    """Verify client.create_document_embedded_view builds the right request and parses responses."""
+
+    def test_success_returns_parsed_model(
+        self,
+        client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """POST /v2/documents/{id}/embedded-view → 200 → CreateDocumentEmbeddedViewResponse."""
+        # ARRANGE
+        fixture = load_fixture("post_embedded_view__success")
+        route = mock_api.post("/v2/documents/doc_001/embedded-view").respond(200, json=fixture)
+        request_data = CreateDocumentEmbeddedViewRequest()
+
+        # ACT
+        result = client.create_document_embedded_view(
+            token=token,
+            document_id="doc_001",
+            request_data=request_data,
+        )
+
+        # ASSERT — response parsed into correct model
+        assert isinstance(result, CreateDocumentEmbeddedViewResponse)
+        assert result.data.link == fixture["data"]["link"]
+
+        # ASSERT — request was built correctly
+        assert route.called
+        request = route.calls.last.request
+        assert request.method == "POST"
+        assert request.url.path == "/v2/documents/doc_001/embedded-view"
+        assert request.headers["authorization"] == f"Bearer {token}"
+        assert request.headers["content-type"] == "application/json"
+        assert request.headers["accept"] == "application/json"
+
+    def test_not_found_raises(
+        self,
+        client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """POST /v2/documents/{id}/embedded-view → 404 → SignNowAPINotFoundError."""
+        # ARRANGE
+        error_fixture = load_fixture("error__document_not_found")
+        route = mock_api.post("/v2/documents/doc_999/embedded-view").respond(
+            404,
+            json=error_fixture,
+        )
+        request_data = CreateDocumentEmbeddedViewRequest()
+
+        # ACT & ASSERT
+        with pytest.raises(SignNowAPINotFoundError) as exc_info:
+            client.create_document_embedded_view(
+                token=token,
+                document_id="doc_999",
+                request_data=request_data,
+            )
+
+        assert route.called
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.response_data == error_fixture
+
+
+class TestCreateDocumentGroupEmbeddedView:
+    """Verify client.create_document_group_embedded_view builds the right request and parses responses."""
+
+    def test_success_returns_parsed_model(
+        self,
+        client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """POST /v2/document-groups/{id}/embedded-view → 200 → CreateDocumentGroupEmbeddedViewResponse."""
+        # ARRANGE
+        fixture = load_fixture("post_embedded_view_group__success")
+        route = mock_api.post("/v2/document-groups/grp_001/embedded-view").respond(200, json=fixture)
+        request_data = CreateDocumentGroupEmbeddedViewRequest()
+
+        # ACT
+        result = client.create_document_group_embedded_view(
+            token=token,
+            document_group_id="grp_001",
+            request_data=request_data,
+        )
+
+        # ASSERT — response parsed into correct model
+        assert isinstance(result, CreateDocumentGroupEmbeddedViewResponse)
+        assert result.data.link == fixture["data"]["link"]
+
+        # ASSERT — request was built correctly
+        assert route.called
+        request = route.calls.last.request
+        assert request.method == "POST"
+        assert request.url.path == "/v2/document-groups/grp_001/embedded-view"
+        assert request.headers["authorization"] == f"Bearer {token}"
+        assert request.headers["content-type"] == "application/json"
+        assert request.headers["accept"] == "application/json"
+
+    def test_not_found_raises(
+        self,
+        client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """POST /v2/document-groups/{id}/embedded-view → 404 → SignNowAPINotFoundError."""
+        # ARRANGE
+        error_fixture = load_fixture("error__document_not_found")
+        route = mock_api.post("/v2/document-groups/grp_999/embedded-view").respond(
+            404,
+            json=error_fixture,
+        )
+        request_data = CreateDocumentGroupEmbeddedViewRequest()
+
+        # ACT & ASSERT
+        with pytest.raises(SignNowAPINotFoundError) as exc_info:
+            client.create_document_group_embedded_view(
+                token=token,
+                document_group_id="grp_999",
+                request_data=request_data,
+            )
+
+        assert route.called
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.response_data == error_fixture

--- a/tests/integration/fixtures/post_embedded_view__success.json
+++ b/tests/integration/fixtures/post_embedded_view__success.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "link": "https://app.signnow.com/webapp/document/doc1?access_token=view-token-abc&embedded=1"
+  }
+}

--- a/tests/integration/fixtures/post_embedded_view_group__success.json
+++ b/tests/integration/fixtures/post_embedded_view_group__success.json
@@ -1,0 +1,1 @@
+{"data": {"link": "https://app.signnow.com/webapp/document-group/grp1?access_token=view-token-grp&embedded=1"}}

--- a/tests/integration/test_view_document.py
+++ b/tests/integration/test_view_document.py
@@ -1,0 +1,226 @@
+"""
+Integration tests for _view_document — tool function wired to real SignNowAPIClient.
+
+HTTP layer is mocked via respx; no real network calls.
+Tests validate the full flow: tool function → SignNowAPIClient → HTTP construction → response parsing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+import respx
+
+from signnow_client import SignNowAPIClient
+from signnow_client.exceptions import SignNowAPINotFoundError
+from sn_mcp_server.tools.document_view import _view_document
+from sn_mcp_server.tools.models import ViewDocumentResponse
+
+DOC_ID = "doc1"
+GRP_ID = "grp1"
+
+
+class TestViewDocumentGroupExplicit:
+    """Integration tests for _view_document with entity_type='document_group'."""
+
+    def test_happy_path_returns_view_response(
+        self,
+        sn_client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """Document group → name fetched, embedded view created, ViewDocumentResponse returned."""
+        # ARRANGE
+        group_fixture = load_fixture("get_document_group_v2__with_pending_invite")
+        view_fixture = load_fixture("post_embedded_view_group__success")
+
+        mock_api.get(f"/v2/document-groups/{GRP_ID}").respond(200, json=group_fixture)
+        mock_api.post(f"/v2/document-groups/{GRP_ID}/embedded-view").respond(200, json=view_fixture)
+
+        # ACT
+        result = _view_document(
+            client=sn_client,
+            token=token,
+            entity_id=GRP_ID,
+            entity_type="document_group",
+            link_expiration_minutes=None,
+        )
+
+        # ASSERT
+        assert isinstance(result, ViewDocumentResponse)
+        assert result.entity_id == GRP_ID
+        assert result.entity_type == "document_group"
+        assert result.document_name == group_fixture["data"]["name"]
+        assert result.view_link == view_fixture["data"]["link"]
+
+    def test_not_found_propagates_error(
+        self,
+        sn_client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """404 on GET document group → SignNowAPINotFoundError propagates to caller."""
+        # ARRANGE
+        error_fixture = load_fixture("error__document_not_found")
+        mock_api.get(f"/v2/document-groups/{GRP_ID}").respond(404, json=error_fixture)
+
+        # ACT & ASSERT
+        with pytest.raises(SignNowAPINotFoundError):
+            _view_document(
+                client=sn_client,
+                token=token,
+                entity_id=GRP_ID,
+                entity_type="document_group",
+                link_expiration_minutes=None,
+            )
+
+
+class TestViewDocumentExplicit:
+    """Integration tests for _view_document with entity_type='document'."""
+
+    def test_happy_path_returns_view_response(
+        self,
+        sn_client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """Document → name fetched, embedded view created, ViewDocumentResponse returned."""
+        # ARRANGE
+        doc_fixture = load_fixture("get_document__with_pending_invite")
+        view_fixture = load_fixture("post_embedded_view__success")
+
+        mock_api.get(f"/document/{DOC_ID}").respond(200, json=doc_fixture)
+        mock_api.post(f"/v2/documents/{DOC_ID}/embedded-view").respond(200, json=view_fixture)
+
+        # ACT
+        result = _view_document(
+            client=sn_client,
+            token=token,
+            entity_id=DOC_ID,
+            entity_type="document",
+            link_expiration_minutes=None,
+        )
+
+        # ASSERT
+        assert isinstance(result, ViewDocumentResponse)
+        assert result.entity_id == DOC_ID
+        assert result.entity_type == "document"
+        assert result.document_name == doc_fixture["document_name"]
+        assert result.view_link == view_fixture["data"]["link"]
+
+    def test_not_found_propagates_error(
+        self,
+        sn_client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """404 on GET document → SignNowAPINotFoundError propagates to caller."""
+        # ARRANGE
+        error_fixture = load_fixture("error__document_not_found")
+        mock_api.get("/document/doc-missing").respond(404, json=error_fixture)
+
+        # ACT & ASSERT
+        with pytest.raises(SignNowAPINotFoundError):
+            _view_document(
+                client=sn_client,
+                token=token,
+                entity_id="doc-missing",
+                entity_type="document",
+                link_expiration_minutes=None,
+            )
+
+
+class TestViewDocumentAutoDetect:
+    """Integration tests for _view_document with entity_type=None (auto-detection)."""
+
+    def test_auto_detects_document_group_first(
+        self,
+        sn_client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """entity_type=None → tries document_group first → succeeds → document not called."""
+        # ARRANGE
+        group_fixture = load_fixture("get_document_group_v2__with_pending_invite")
+        view_fixture = load_fixture("post_embedded_view_group__success")
+
+        group_route = mock_api.get(f"/v2/document-groups/{GRP_ID}").respond(200, json=group_fixture)
+        mock_api.post(f"/v2/document-groups/{GRP_ID}/embedded-view").respond(200, json=view_fixture)
+
+        # ACT
+        result = _view_document(
+            client=sn_client,
+            token=token,
+            entity_id=GRP_ID,
+            entity_type=None,
+            link_expiration_minutes=None,
+        )
+
+        # ASSERT — resolved as document_group
+        assert isinstance(result, ViewDocumentResponse)
+        assert result.entity_type == "document_group"
+        assert result.document_name == group_fixture["data"]["name"]
+        assert result.view_link == view_fixture["data"]["link"]
+        assert group_route.called
+
+    def test_auto_detect_falls_back_to_document(
+        self,
+        sn_client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """entity_type=None → group 404 → falls back to document → succeeds."""
+        # ARRANGE
+        error_fixture = load_fixture("error__document_not_found")
+        doc_fixture = load_fixture("get_document__with_pending_invite")
+        view_fixture = load_fixture("post_embedded_view__success")
+
+        mock_api.get(f"/v2/document-groups/{DOC_ID}").respond(404, json=error_fixture)
+        mock_api.get(f"/document/{DOC_ID}").respond(200, json=doc_fixture)
+        mock_api.post(f"/v2/documents/{DOC_ID}/embedded-view").respond(200, json=view_fixture)
+
+        # ACT
+        result = _view_document(
+            client=sn_client,
+            token=token,
+            entity_id=DOC_ID,
+            entity_type=None,
+            link_expiration_minutes=None,
+        )
+
+        # ASSERT — resolved as document
+        assert isinstance(result, ViewDocumentResponse)
+        assert result.entity_type == "document"
+        assert result.document_name == doc_fixture["document_name"]
+        assert result.view_link == view_fixture["data"]["link"]
+
+    def test_auto_detect_raises_when_both_not_found(
+        self,
+        sn_client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """entity_type=None → both 404 → ValueError with entity_id in message."""
+        # ARRANGE
+        error_fixture = load_fixture("error__document_not_found")
+        mock_api.get("/v2/document-groups/unknown-id").respond(404, json=error_fixture)
+        mock_api.get("/document/unknown-id").respond(404, json=error_fixture)
+
+        # ACT & ASSERT
+        with pytest.raises(ValueError, match="unknown-id"):
+            _view_document(
+                client=sn_client,
+                token=token,
+                entity_id="unknown-id",
+                entity_type=None,
+                link_expiration_minutes=None,
+            )

--- a/tests/integration/test_view_document.py
+++ b/tests/integration/test_view_document.py
@@ -14,7 +14,7 @@ import pytest
 import respx
 
 from signnow_client import SignNowAPIClient
-from signnow_client.exceptions import SignNowAPINotFoundError
+from signnow_client.exceptions import SignNowAPIAuthenticationError, SignNowAPINotFoundError
 from sn_mcp_server.tools.document_view import _view_document
 from sn_mcp_server.tools.models import ViewDocumentResponse
 
@@ -221,6 +221,29 @@ class TestViewDocumentAutoDetect:
                 client=sn_client,
                 token=token,
                 entity_id="unknown-id",
+                entity_type=None,
+                link_expiration_minutes=None,
+            )
+
+    def test_non_404_on_group_probe_propagates(
+        self,
+        sn_client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+    ) -> None:
+        """entity_type=None → group returns 403 → SignNowAPIAuthenticationError propagates, no doc fallback."""
+        # ARRANGE — 403 from group endpoint, doc endpoint should never be called
+        mock_api.get(f"/v2/document-groups/{DOC_ID}").respond(
+            403,
+            json={"errors": [{"code": "403", "message": "Forbidden"}]},
+        )
+
+        # ACT & ASSERT
+        with pytest.raises(SignNowAPIAuthenticationError):
+            _view_document(
+                client=sn_client,
+                token=token,
+                entity_id=DOC_ID,
                 entity_type=None,
                 link_expiration_minutes=None,
             )

--- a/tests/unit/sn_mcp_server/tools/test_document_view.py
+++ b/tests/unit/sn_mcp_server/tools/test_document_view.py
@@ -1,0 +1,249 @@
+"""Unit tests for document_view.py — _view_document business logic."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from signnow_client.exceptions import SignNowAPIError
+from signnow_client.models.document_groups import (
+    CreateDocumentGroupEmbeddedViewResponse,
+    DocumentGroupV2Data,
+    EmbeddedViewData,
+    GetDocumentGroupV2Response,
+)
+from signnow_client.models.templates_and_documents import (
+    CreateDocumentEmbeddedViewResponse,
+    DocumentResponse,
+)
+from sn_mcp_server.tools.document_view import _view_document
+from sn_mcp_server.tools.models import ViewDocumentResponse
+
+TOKEN = "unit-test-token"  # noqa: S105
+DOC_ID = "doc-abc"
+GRP_ID = "grp-xyz"
+VIEW_LINK = "https://app.signnow.com/webapp/document/doc-abc?access_token=tok&embedded=1"
+
+
+# ---------------------------------------------------------------------------
+# Factory helpers
+# ---------------------------------------------------------------------------
+
+
+def _group_resp(name: str = "My Group") -> GetDocumentGroupV2Response:
+    """Minimal GetDocumentGroupV2Response — only data.name is accessed by _view_document."""
+    data = DocumentGroupV2Data.model_construct(name=name, documents=[])
+    return GetDocumentGroupV2Response.model_construct(data=data)
+
+
+def _doc_resp(name: str = "My Doc") -> DocumentResponse:
+    """Minimal DocumentResponse — only document_name is accessed."""
+    return DocumentResponse.model_construct(document_name=name)
+
+
+def _group_view_resp(link: str = VIEW_LINK) -> CreateDocumentGroupEmbeddedViewResponse:
+    """CreateDocumentGroupEmbeddedViewResponse with a link."""
+    return CreateDocumentGroupEmbeddedViewResponse(data=EmbeddedViewData(link=link))
+
+
+def _doc_view_resp(link: str = VIEW_LINK) -> CreateDocumentEmbeddedViewResponse:
+    """CreateDocumentEmbeddedViewResponse with a link."""
+    return CreateDocumentEmbeddedViewResponse(data=CreateDocumentEmbeddedViewResponse.Data(link=link))
+
+
+# ---------------------------------------------------------------------------
+# Tests: explicit entity_type='document_group'
+# ---------------------------------------------------------------------------
+
+
+class TestViewDocumentGroupExplicit:
+    """Tests for _view_document(entity_type='document_group')."""
+
+    @pytest.fixture()
+    def mock_client(self) -> MagicMock:
+        """Client with a document_group found and embedded view created."""
+        client = MagicMock()
+        client.get_document_group_v2.return_value = _group_resp("Sales Proposal")
+        client.create_document_group_embedded_view.return_value = _group_view_resp()
+        return client
+
+    def test_returns_view_document_response(self, mock_client: MagicMock) -> None:
+        """Explicit document_group → result is ViewDocumentResponse."""
+        result = _view_document(GRP_ID, "document_group", None, TOKEN, mock_client)
+        assert isinstance(result, ViewDocumentResponse)
+
+    def test_view_link_extracted(self, mock_client: MagicMock) -> None:
+        """view_link matches embedded view response data.link."""
+        result = _view_document(GRP_ID, "document_group", None, TOKEN, mock_client)
+        assert result.view_link == VIEW_LINK
+
+    def test_entity_id_and_type_set(self, mock_client: MagicMock) -> None:
+        """entity_id and entity_type set correctly."""
+        result = _view_document(GRP_ID, "document_group", None, TOKEN, mock_client)
+        assert result.entity_id == GRP_ID
+        assert result.entity_type == "document_group"
+
+    def test_document_name_fetched_from_group(self, mock_client: MagicMock) -> None:
+        """document_name comes from get_document_group_v2 data.name."""
+        result = _view_document(GRP_ID, "document_group", None, TOKEN, mock_client)
+        assert result.document_name == "Sales Proposal"
+
+    def test_link_expiration_forwarded(self, mock_client: MagicMock) -> None:
+        """link_expiration_minutes forwarded to CreateDocumentGroupEmbeddedViewRequest."""
+        _view_document(GRP_ID, "document_group", 86400, TOKEN, mock_client)
+
+        args = mock_client.create_document_group_embedded_view.call_args[0]
+        request = args[2]
+        assert request.link_expiration == 86400
+
+    def test_group_id_passed_to_embedded_view(self, mock_client: MagicMock) -> None:
+        """document_group_id passed correctly to create_document_group_embedded_view."""
+        _view_document(GRP_ID, "document_group", None, TOKEN, mock_client)
+
+        args = mock_client.create_document_group_embedded_view.call_args[0]
+        assert args[1] == GRP_ID
+
+    def test_get_document_not_called(self, mock_client: MagicMock) -> None:
+        """get_document is never called for entity_type='document_group'."""
+        _view_document(GRP_ID, "document_group", None, TOKEN, mock_client)
+        mock_client.get_document.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: explicit entity_type='document'
+# ---------------------------------------------------------------------------
+
+
+class TestViewDocumentExplicit:
+    """Tests for _view_document(entity_type='document')."""
+
+    @pytest.fixture()
+    def mock_client(self) -> MagicMock:
+        """Client with a document found and embedded view created."""
+        client = MagicMock()
+        client.get_document.return_value = _doc_resp("Invoice Q4")
+        client.create_document_embedded_view.return_value = _doc_view_resp()
+        return client
+
+    def test_returns_view_document_response(self, mock_client: MagicMock) -> None:
+        """Explicit document → result is ViewDocumentResponse."""
+        result = _view_document(DOC_ID, "document", None, TOKEN, mock_client)
+        assert isinstance(result, ViewDocumentResponse)
+
+    def test_view_link_extracted(self, mock_client: MagicMock) -> None:
+        """view_link matches embedded view response data.link."""
+        result = _view_document(DOC_ID, "document", None, TOKEN, mock_client)
+        assert result.view_link == VIEW_LINK
+
+    def test_entity_id_and_type_set(self, mock_client: MagicMock) -> None:
+        """entity_id and entity_type set correctly."""
+        result = _view_document(DOC_ID, "document", None, TOKEN, mock_client)
+        assert result.entity_id == DOC_ID
+        assert result.entity_type == "document"
+
+    def test_document_name_fetched_from_doc(self, mock_client: MagicMock) -> None:
+        """document_name comes from DocumentResponse.document_name."""
+        result = _view_document(DOC_ID, "document", None, TOKEN, mock_client)
+        assert result.document_name == "Invoice Q4"
+
+    def test_link_expiration_forwarded(self, mock_client: MagicMock) -> None:
+        """link_expiration_minutes forwarded to CreateDocumentEmbeddedViewRequest."""
+        _view_document(DOC_ID, "document", 43200, TOKEN, mock_client)
+
+        args = mock_client.create_document_embedded_view.call_args[0]
+        request = args[2]
+        assert request.link_expiration == 43200
+
+    def test_doc_id_passed_to_embedded_view(self, mock_client: MagicMock) -> None:
+        """document_id passed correctly to create_document_embedded_view."""
+        _view_document(DOC_ID, "document", None, TOKEN, mock_client)
+
+        args = mock_client.create_document_embedded_view.call_args[0]
+        assert args[1] == DOC_ID
+
+    def test_get_document_group_not_called(self, mock_client: MagicMock) -> None:
+        """get_document_group_v2 is never called for entity_type='document'."""
+        _view_document(DOC_ID, "document", None, TOKEN, mock_client)
+        mock_client.get_document_group_v2.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: auto-detect (entity_type=None)
+# ---------------------------------------------------------------------------
+
+
+class TestViewDocumentAutoDetect:
+    """Tests for _view_document(entity_type=None) — auto-detection logic."""
+
+    def test_group_detected_first(self) -> None:
+        """Auto-detect: group found → entity_type='document_group', name set."""
+        client = MagicMock()
+        client.get_document_group_v2.return_value = _group_resp("Group A")
+        client.create_document_group_embedded_view.return_value = _group_view_resp()
+
+        result = _view_document(GRP_ID, None, None, TOKEN, client)
+
+        assert result.entity_type == "document_group"
+        assert result.document_name == "Group A"
+
+    def test_group_found_document_api_not_called(self) -> None:
+        """Auto-detect: group found → get_document never called."""
+        client = MagicMock()
+        client.get_document_group_v2.return_value = _group_resp()
+        client.create_document_group_embedded_view.return_value = _group_view_resp()
+
+        _view_document(GRP_ID, None, None, TOKEN, client)
+
+        client.get_document.assert_not_called()
+
+    def test_group_found_name_not_refetched(self) -> None:
+        """Auto-detect: name set during detection — get_document_group_v2 called only once."""
+        client = MagicMock()
+        client.get_document_group_v2.return_value = _group_resp()
+        client.create_document_group_embedded_view.return_value = _group_view_resp()
+
+        _view_document(GRP_ID, None, None, TOKEN, client)
+
+        client.get_document_group_v2.assert_called_once()
+
+    def test_fallback_to_document_when_group_raises(self) -> None:
+        """Auto-detect: group API raises → falls back to document."""
+        client = MagicMock()
+        client.get_document_group_v2.side_effect = SignNowAPIError("Not Found", 404)
+        client.get_document.return_value = _doc_resp("Fallback Doc")
+        client.create_document_embedded_view.return_value = _doc_view_resp()
+
+        result = _view_document(DOC_ID, None, None, TOKEN, client)
+
+        assert result.entity_type == "document"
+        assert result.document_name == "Fallback Doc"
+
+    def test_fallback_document_name_not_refetched(self) -> None:
+        """Auto-detect: fallback doc name set during detection — get_document called once."""
+        client = MagicMock()
+        client.get_document_group_v2.side_effect = SignNowAPIError("Not Found", 404)
+        client.get_document.return_value = _doc_resp()
+        client.create_document_embedded_view.return_value = _doc_view_resp()
+
+        _view_document(DOC_ID, None, None, TOKEN, client)
+
+        client.get_document.assert_called_once()
+
+    def test_raises_value_error_when_both_not_found(self) -> None:
+        """Auto-detect: both group and document raise → ValueError with entity_id in message."""
+        client = MagicMock()
+        client.get_document_group_v2.side_effect = SignNowAPIError("Not Found", 404)
+        client.get_document.side_effect = SignNowAPIError("Not Found", 404)
+
+        with pytest.raises(ValueError, match="unknown-id"):
+            _view_document("unknown-id", None, None, TOKEN, client)
+
+    def test_value_error_message_mentions_not_found(self) -> None:
+        """ValueError message contains 'not found' context."""
+        client = MagicMock()
+        client.get_document_group_v2.side_effect = Exception("timeout")
+        client.get_document.side_effect = Exception("timeout")
+
+        with pytest.raises(ValueError, match="not found"):
+            _view_document("bad-id", None, None, TOKEN, client)

--- a/tests/unit/sn_mcp_server/tools/test_document_view.py
+++ b/tests/unit/sn_mcp_server/tools/test_document_view.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from signnow_client.exceptions import SignNowAPIError
+from signnow_client.exceptions import SignNowAPIAuthenticationError, SignNowAPINotFoundError
 from signnow_client.models.document_groups import (
     CreateDocumentGroupEmbeddedViewResponse,
     DocumentGroupV2Data,
@@ -208,9 +208,9 @@ class TestViewDocumentAutoDetect:
         client.get_document_group_v2.assert_called_once()
 
     def test_fallback_to_document_when_group_raises(self) -> None:
-        """Auto-detect: group API raises → falls back to document."""
+        """Auto-detect: group 404 → falls back to document."""
         client = MagicMock()
-        client.get_document_group_v2.side_effect = SignNowAPIError("Not Found", 404)
+        client.get_document_group_v2.side_effect = SignNowAPINotFoundError("group not found")
         client.get_document.return_value = _doc_resp("Fallback Doc")
         client.create_document_embedded_view.return_value = _doc_view_resp()
 
@@ -222,7 +222,7 @@ class TestViewDocumentAutoDetect:
     def test_fallback_document_name_not_refetched(self) -> None:
         """Auto-detect: fallback doc name set during detection — get_document called once."""
         client = MagicMock()
-        client.get_document_group_v2.side_effect = SignNowAPIError("Not Found", 404)
+        client.get_document_group_v2.side_effect = SignNowAPINotFoundError("group not found")
         client.get_document.return_value = _doc_resp()
         client.create_document_embedded_view.return_value = _doc_view_resp()
 
@@ -231,19 +231,29 @@ class TestViewDocumentAutoDetect:
         client.get_document.assert_called_once()
 
     def test_raises_value_error_when_both_not_found(self) -> None:
-        """Auto-detect: both group and document raise → ValueError with entity_id in message."""
+        """Auto-detect: both group and document 404 → ValueError with entity_id in message."""
         client = MagicMock()
-        client.get_document_group_v2.side_effect = SignNowAPIError("Not Found", 404)
-        client.get_document.side_effect = SignNowAPIError("Not Found", 404)
+        client.get_document_group_v2.side_effect = SignNowAPINotFoundError("group not found")
+        client.get_document.side_effect = SignNowAPINotFoundError("doc not found")
 
         with pytest.raises(ValueError, match="unknown-id"):
             _view_document("unknown-id", None, None, TOKEN, client)
 
-    def test_value_error_message_mentions_not_found(self) -> None:
-        """ValueError message contains 'not found' context."""
+    def test_non_404_error_on_group_probe_propagates(self) -> None:
+        """Auto-detect: non-404 API error on group probe → propagates, does NOT fall back."""
         client = MagicMock()
-        client.get_document_group_v2.side_effect = Exception("timeout")
-        client.get_document.side_effect = Exception("timeout")
+        client.get_document_group_v2.side_effect = SignNowAPIAuthenticationError("Unauthorized", 401)
 
-        with pytest.raises(ValueError, match="not found"):
-            _view_document("bad-id", None, None, TOKEN, client)
+        with pytest.raises(SignNowAPIAuthenticationError):
+            _view_document(DOC_ID, None, None, TOKEN, client)
+
+        client.get_document.assert_not_called()
+
+    def test_non_404_error_on_doc_probe_propagates(self) -> None:
+        """Auto-detect: group 404, non-404 error on doc probe → doc error propagates, not ValueError."""
+        client = MagicMock()
+        client.get_document_group_v2.side_effect = SignNowAPINotFoundError("group not found")
+        client.get_document.side_effect = SignNowAPIAuthenticationError("Unauthorized", 401)
+
+        with pytest.raises(SignNowAPIAuthenticationError):
+            _view_document(DOC_ID, None, None, TOKEN, client)


### PR DESCRIPTION
## Summary

Implements **SN-30532** — inline document preview via MCP Apps protocol.

When `view_document` is called, ChatGPT and other MCP Apps-compatible hosts render the SignNow embedded viewer directly inline in the chat, instead of showing a plain link.

## Changes

### `signnow_client`
- New models: `CreateDocumentEmbeddedViewRequest/Response` (documents) and `CreateDocumentGroupEmbeddedViewRequest/Response` (document groups)
- New client methods: `create_document_embedded_view()` and `create_document_group_embedded_view()`

### `sn_mcp_server/tools`
- **`document_view.py`** — new module: auto-detects entity type (document_group first, then document), calls the appropriate embedded-view API, returns `ViewDocumentResponse` with `view_link`
- **`models.py`** — new `ViewDocumentResponse` with `view_link` + `document_name`
- **`signnow.py`** — registers `view_document` tool with `meta.ui.resourceUri` and `get_document_viewer_ui` resource with `mime_type=text/html;profile=mcp-app`
- **`static/document_viewer.html`** — MCP Apps view: JSON-RPC 2.0 handshake over postMessage, renders SignNow embedded viewer in iframe

## Reload recovery

ChatGPT intermittently doesn't replay `tool-result` after page reload (host-side bug). Per MCP Apps documentation recommendation ("use localStorage or server-side state"), we use `sessionStorage` as a fallback: result is cached on first render, restored after 3 s if host doesn't deliver. Each ChatGPT tool call runs in a unique sandbox origin (`connector_HASH`), so storage is isolated per document.
