### PR TITLE
Fix HTTP header filtering in _get_token_and_client

### DIFF
--- a/src/sn_mcp_server/tools/signnow.py
+++ b/src/sn_mcp_server/tools/signnow.py
@@ -78,7 +78,7 @@ def _get_token_and_client(token_provider: TokenProvider) -> tuple[str, SignNowAP
     Raises:
         ValueError: If no access token is available
     """
-    headers = get_http_headers()
+    headers = get_http_headers(include={"authorization"})
     token = token_provider.get_access_token(headers)
 
     if not token:


### PR DESCRIPTION
## Summary

Pass `include={"authorization"}` to `get_http_headers()` in `_get_token_and_client` so only the `Authorization` header is extracted from the incoming request. Previously, calling `get_http_headers()` without arguments returned all headers, which is unnecessary and potentially unsafe for token extraction.

## Changes

- `src/sn_mcp_server/tools/signnow.py`: Pass `include={"authorization"}` to `get_http_headers()` in `_get_token_and_client`

## Tests

No new tests required — this is a targeted one-line fix to header filtering. Existing unit tests (`347 passed, 1 skipped`) continue to pass.