### PR TITLE
Add embedded sender as MCP App inline UI

### DIFF
--- a/src/sn_mcp_server/tools/embedded_sending.py
+++ b/src/sn_mcp_server/tools/embedded_sending.py
@@ -5,6 +5,7 @@ This module contains functions for creating embedded sending for documents and d
 from the SignNow API.
 """
 
+import pathlib
 from typing import Literal
 
 from fastmcp import Context
@@ -16,6 +17,13 @@ from .models import (
     CreateEmbeddedSendingResponse,
 )
 from .utils import _detect_entity_type
+
+SENDER_RESOURCE_URI: str = "ui://signnow/embedded-sender"
+"""MCP Apps resource URI for the inline embedded sender UI."""
+
+_STATIC_DIR = pathlib.Path(__file__).parent / "static"
+_SENDER_HTML: str = (_STATIC_DIR / "embedded_sender.html").read_text(encoding="utf-8")
+"""Pre-loaded HTML content for the embedded sender MCP App."""
 
 
 def _create_document_group_embedded_sending(

--- a/src/sn_mcp_server/tools/signnow.py
+++ b/src/sn_mcp_server/tools/signnow.py
@@ -24,6 +24,8 @@ from .embedded_invite import (
     _create_embedded_invite,
 )
 from .embedded_sending import (
+    _SENDER_HTML,
+    SENDER_RESOURCE_URI,
     _create_embedded_sending,
 )
 from .invite_status import _get_invite_status
@@ -433,8 +435,10 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
         name="create_embedded_sending",
         description=(
             "Create embedded sending for managing, editing, or sending invites for a document, document group, template, or template group. "
-            "For templates and template groups, automatically creates a document/group first, then creates the embedded sending."
+            "For templates and template groups, automatically creates a document/group first, then creates the embedded sending. "
+            "In MCP Apps-compatible hosts (MCP Inspector, VS Code, Goose, LibreChat) the sender UI renders inline — no tab switch needed."
         ),
+        meta={"ui": {"resourceUri": SENDER_RESOURCE_URI}},
         annotations=ToolAnnotations(
             title="Create embedded sending link",
             readOnlyHint=False,
@@ -1124,6 +1128,16 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
     def get_document_viewer_ui() -> str:
         """Return the MCP Apps HTML viewer for inline document rendering."""
         return _VIEWER_HTML
+
+    @mcp.resource(
+        SENDER_RESOURCE_URI,
+        name="embedded_sender_app",
+        description="MCP Apps inline UI for SignNow Embedded Sender. Returns an HTML page that renders the embedded sender inside a sandboxed iframe.",
+        mime_type="text/html;profile=mcp-app",
+    )
+    def get_embedded_sender_ui() -> str:
+        """Return the MCP Apps HTML for inline embedded sender rendering."""
+        return _SENDER_HTML
 
     async def _list_contacts_impl(query: str | None = None, per_page: int = 15) -> ContactListResponse:
         token, client = _get_token_and_client(token_provider)

--- a/src/sn_mcp_server/tools/signnow.py
+++ b/src/sn_mcp_server/tools/signnow.py
@@ -436,7 +436,7 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
         description=(
             "Create embedded sending for managing, editing, or sending invites for a document, document group, template, or template group. "
             "For templates and template groups, automatically creates a document/group first, then creates the embedded sending. "
-            "In MCP Apps-compatible hosts (MCP Inspector, VS Code, Goose, LibreChat) the sender UI renders inline — no tab switch needed."
+            "In MCP Apps-compatible clients the sender UI renders inline — no tab switch needed."
         ),
         meta={"ui": {"resourceUri": SENDER_RESOURCE_URI}},
         annotations=ToolAnnotations(
@@ -1069,7 +1069,7 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
             "Generate a read-only embedded view link for a document or document group. "
             "To find an entity by name, first call list_documents or list_templates "
             "to search for it, then pass the returned entity_id here. "
-            "In MCP Apps-compatible hosts (MCP Inspector, VS Code, Goose, LibreChat) "
+            "In MCP Apps-compatible clients "
             "the document renders inline — no tab switch needed. "
             "In other hosts, the returned view_link is presented as a clickable URL."
         ),

--- a/src/sn_mcp_server/tools/static/embedded_sender.html
+++ b/src/sn_mcp_server/tools/static/embedded_sender.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: system-ui, -apple-system, sans-serif; height: 100vh; display: flex;
+           flex-direction: column; background: #f8f9fa; }
+    #loading { flex: 1; display: flex; justify-content: center; align-items: center;
+               color: #6b7280; font-size: 14px; }
+    #error { flex: 1; display: flex; justify-content: center; align-items: center;
+             color: #dc2626; font-size: 14px; padding: 20px; text-align: center; }
+    #header { padding: 8px 16px; background: #fff; border-bottom: 1px solid #e5e7eb;
+              font-size: 13px; color: #374151; align-items: center; gap: 8px; }
+    #header .name { font-weight: 600; }
+    #header .link { color: #4f46e5; text-decoration: none; font-size: 12px; margin-left: auto; }
+    #header .link:hover { text-decoration: underline; }
+    #viewer { flex: 1; border: none; width: 100%; }
+  </style>
+</head>
+<body>
+  <div id="header" style="display:none">
+    <span class="name" id="sender-label"></span>
+    <a class="link" id="open-link" href="#" target="_blank" rel="noopener">Open in SignNow ↗</a>
+  </div>
+  <div id="loading">Loading Embedded Sender&#8230;</div>
+  <div id="error" style="display:none"></div>
+  <iframe id="viewer" style="display:none" sandbox="allow-scripts allow-same-origin allow-popups allow-forms"></iframe>
+
+  <script>
+    /**
+     * MCP Apps Embedded Sender — JSON-RPC 2.0 over postMessage protocol.
+     *
+     * Architecture: Host ↔ outer sandbox proxy ↔ THIS iframe (inner)
+     * We communicate with window.parent (outer sandbox), which relays to the host.
+     *
+     * Lifecycle:
+     *   1. We send  ui/initialize request
+     *   2. Host responds with capabilities
+     *   3. We send  ui/notifications/initialized
+     *   4. Host fires oninitialized → sends ui/notifications/tool-input
+     *   5. Host sends ui/notifications/tool-result  ← we render the sender here
+     *
+     * Reload recovery:
+     *   ChatGPT sometimes doesn't replay tool-result after page reload.
+     *   MCP Apps docs recommend localStorage/sessionStorage for state persistence.
+     *   Each ChatGPT tool call runs in a unique sandbox origin (connector_HASH),
+     *   so sessionStorage is per-document and never collides.
+     */
+
+    var _senderRendered = false;
+    var _nextId = 1;
+    var _pending = {};
+
+    function _send(msg) {
+      window.parent.postMessage(msg, '*');
+    }
+
+    function _request(method, params) {
+      var id = _nextId++;
+      return new Promise(function(resolve, reject) {
+        _pending[id] = { resolve: resolve, reject: reject };
+        _send({ jsonrpc: '2.0', id: id, method: method, params: params || {} });
+      });
+    }
+
+    function _requestSize(width, height) {
+      var params = {};
+      if (width != null)  params.width  = width;
+      if (height != null) params.height = height;
+      _send({ jsonrpc: '2.0', method: 'ui/notifications/size-changed', params: params });
+    }
+
+    function _showSender(params) {
+      var sc = params.structuredContent || {};
+      var link = sc.sending_url;
+      var entity = sc.sending_entity || '';
+
+      if (!link && Array.isArray(params.content)) {
+        for (var i = 0; i < params.content.length; i++) {
+          var block = params.content[i];
+          if (block.type === 'text' && block.text) {
+            try {
+              var parsed = JSON.parse(block.text);
+              if (parsed.sending_url) { link = parsed.sending_url; entity = parsed.sending_entity || entity; }
+            } catch (_) {}
+          }
+        }
+      }
+
+      if (!link) return;
+
+      _senderRendered = true;
+
+      /* Persist for reload recovery (per MCP Apps recommendation). */
+      try { sessionStorage.setItem('sn_sender', JSON.stringify({ link: link, entity: entity })); }
+      catch (_) {}
+
+      document.getElementById('loading').style.display = 'none';
+      document.getElementById('error').style.display = 'none';
+
+      var header = document.getElementById('header');
+      header.style.display = 'flex';
+      var label = 'Embedded Sender' + (entity ? ' — ' + entity : '');
+      document.getElementById('sender-label').textContent = label;
+      document.getElementById('open-link').href = link;
+
+      var viewer = document.getElementById('viewer');
+      viewer.src = link;
+      viewer.style.display = 'block';
+    }
+
+    /* ── Message handler ── */
+    window.addEventListener('message', function(event) {
+      var data = event.data;
+      if (!data || typeof data !== 'object' || data.jsonrpc !== '2.0') return;
+
+      /* Response to one of our requests */
+      if (data.id !== undefined && _pending[data.id]) {
+        var handler = _pending[data.id];
+        delete _pending[data.id];
+        if (data.error) handler.reject(new Error(data.error.message || 'MCP error'));
+        else handler.resolve(data.result);
+        return;
+      }
+
+      /* Incoming notifications from host */
+      if (data.method === 'ui/notifications/tool-result') {
+        _showSender(data.params || {});
+      }
+    });
+
+    /* ── Initialization handshake ── */
+    var _initDone = false;
+
+    function _sendInitialized() {
+      if (_initDone) return;
+      _initDone = true;
+      _send({ jsonrpc: '2.0', method: 'ui/notifications/initialized', params: {} });
+      _requestSize(null, 900);
+    }
+
+    _request('ui/initialize', {
+      protocolVersion: '2026-01-26',
+      appInfo: { name: 'signnow-embedded-sender', version: '1.0.0' },
+      appCapabilities: {}
+    }).then(function() {
+      _sendInitialized();
+    }).catch(function() {
+      _sendInitialized();
+    });
+
+    /* Fallback: send initialized even if ui/initialize never responds. */
+    setTimeout(_sendInitialized, 2000);
+
+    /* ── Reload recovery via sessionStorage ──
+       If host doesn't deliver tool-result within 3 s, restore from cache. */
+    setTimeout(function() {
+      if (_senderRendered) return;
+      try {
+        var raw = sessionStorage.getItem('sn_sender');
+        if (!raw) return;
+        var cached = JSON.parse(raw);
+        if (cached.link) {
+          _showSender({ structuredContent: { sending_url: cached.link, sending_entity: cached.entity } });
+        }
+      } catch (_) {}
+    }, 3000);
+
+    /* Final fallback: show error after 15 s if nothing worked. */
+    setTimeout(function() {
+      if (document.getElementById('viewer').style.display === 'none') {
+        document.getElementById('loading').style.display = 'none';
+        document.getElementById('error').style.display = 'flex';
+        document.getElementById('error').textContent =
+          'Could not load the Embedded Sender. Use the sending_url returned in the tool result.';
+      }
+    }, 15000);
+  </script>
+</body>
+</html>

--- a/tests/integration/fixtures/post_embedded_sending__success.json
+++ b/tests/integration/fixtures/post_embedded_sending__success.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "url": "https://app.signnow.com/sending/doc1?access_token=send-token-abc&embedded=1"
+  }
+}

--- a/tests/integration/fixtures/post_embedded_sending_group__success.json
+++ b/tests/integration/fixtures/post_embedded_sending_group__success.json
@@ -1,0 +1,1 @@
+{"data": {"url": "https://app.signnow.com/sending/document-group/grp1?access_token=send-token-grp&embedded=1"}}

--- a/tests/integration/test_embedded_sending.py
+++ b/tests/integration/test_embedded_sending.py
@@ -1,0 +1,221 @@
+"""
+Integration tests for _create_embedded_sending — tool function wired to real SignNowAPIClient.
+
+HTTP layer is mocked via respx; no real network calls.
+Tests validate the full flow: tool function → SignNowAPIClient → HTTP construction → response parsing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+import respx
+
+from signnow_client import SignNowAPIClient
+from signnow_client.exceptions import SignNowAPIAuthenticationError, SignNowAPINotFoundError
+from sn_mcp_server.tools.embedded_sending import _create_embedded_sending
+from sn_mcp_server.tools.models import CreateEmbeddedSendingResponse
+
+DOC_ID = "doc1"
+GRP_ID = "grp1"
+
+
+class TestCreateEmbeddedSendingDocumentExplicit:
+    """Integration tests for _create_embedded_sending with entity_type='document'."""
+
+    async def test_happy_path_returns_sending_response(
+        self,
+        sn_client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """Explicit document → POST embedded-sending → CreateEmbeddedSendingResponse returned."""
+        fixture = load_fixture("post_embedded_sending__success")
+        mock_api.post(f"/v2/documents/{DOC_ID}/embedded-sending").respond(200, json=fixture)
+
+        result = await _create_embedded_sending(
+            entity_id=DOC_ID,
+            entity_type="document",
+            redirect_uri=None,
+            redirect_target=None,
+            link_expiration_minutes=None,
+            sending_type="manage",
+            token=token,
+            client=sn_client,
+        )
+
+        assert isinstance(result, CreateEmbeddedSendingResponse)
+        assert result.sending_entity == "document"
+        assert result.sending_url == fixture["data"]["url"]
+        assert result.created_entity_id is None
+        assert result.created_entity_type is None
+
+    async def test_not_found_propagates_error(
+        self,
+        sn_client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """404 on POST embedded-sending → SignNowAPINotFoundError propagates to caller."""
+        error_fixture = load_fixture("error__document_not_found")
+        mock_api.post(f"/v2/documents/{DOC_ID}/embedded-sending").respond(404, json=error_fixture)
+
+        with pytest.raises(SignNowAPINotFoundError):
+            await _create_embedded_sending(
+                entity_id=DOC_ID,
+                entity_type="document",
+                redirect_uri=None,
+                redirect_target=None,
+                link_expiration_minutes=None,
+                sending_type="manage",
+                token=token,
+                client=sn_client,
+            )
+
+
+class TestCreateEmbeddedSendingDocumentGroupExplicit:
+    """Integration tests for _create_embedded_sending with entity_type='document_group'."""
+
+    async def test_happy_path_returns_sending_response(
+        self,
+        sn_client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """Explicit document_group → POST group embedded-sending → CreateEmbeddedSendingResponse."""
+        fixture = load_fixture("post_embedded_sending_group__success")
+        mock_api.post(f"/v2/document-groups/{GRP_ID}/embedded-sending").respond(200, json=fixture)
+
+        result = await _create_embedded_sending(
+            entity_id=GRP_ID,
+            entity_type="document_group",
+            redirect_uri=None,
+            redirect_target=None,
+            link_expiration_minutes=None,
+            sending_type="manage",
+            token=token,
+            client=sn_client,
+        )
+
+        assert isinstance(result, CreateEmbeddedSendingResponse)
+        assert result.sending_entity == "document_group"
+        assert result.sending_url == fixture["data"]["url"]
+        assert result.created_entity_id is None
+
+    async def test_not_found_propagates_error(
+        self,
+        sn_client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """404 on POST group embedded-sending → SignNowAPINotFoundError propagates."""
+        error_fixture = load_fixture("error__document_not_found")
+        mock_api.post(f"/v2/document-groups/{GRP_ID}/embedded-sending").respond(404, json=error_fixture)
+
+        with pytest.raises(SignNowAPINotFoundError):
+            await _create_embedded_sending(
+                entity_id=GRP_ID,
+                entity_type="document_group",
+                redirect_uri=None,
+                redirect_target=None,
+                link_expiration_minutes=None,
+                sending_type="manage",
+                token=token,
+                client=sn_client,
+            )
+
+
+class TestCreateEmbeddedSendingAutoDetect:
+    """Integration tests for _create_embedded_sending with entity_type=None (auto-detection)."""
+
+    async def test_auto_detects_document_group_first(
+        self,
+        sn_client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """entity_type=None → tries document_group first → succeeds → group sending used."""
+        group_fixture = load_fixture("get_document_group__with_roles")
+        sending_fixture = load_fixture("post_embedded_sending_group__success")
+
+        group_route = mock_api.get(f"/documentgroup/{GRP_ID}").respond(200, json=group_fixture)
+        mock_api.post(f"/v2/document-groups/{GRP_ID}/embedded-sending").respond(200, json=sending_fixture)
+
+        result = await _create_embedded_sending(
+            entity_id=GRP_ID,
+            entity_type=None,
+            redirect_uri=None,
+            redirect_target=None,
+            link_expiration_minutes=None,
+            sending_type="manage",
+            token=token,
+            client=sn_client,
+        )
+
+        assert isinstance(result, CreateEmbeddedSendingResponse)
+        assert result.sending_entity == "document_group"
+        assert result.sending_url == sending_fixture["data"]["url"]
+        assert group_route.called
+
+    async def test_auto_detect_falls_back_to_document(
+        self,
+        sn_client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+        load_fixture: Callable[[str], dict[str, Any]],
+    ) -> None:
+        """entity_type=None → group 404 → template_group 404 → document succeeds → doc sending."""
+        error_fixture = load_fixture("error__document_not_found")
+        doc_fixture = load_fixture("get_document__with_pending_invite")
+        sending_fixture = load_fixture("post_embedded_sending__success")
+
+        mock_api.get(f"/documentgroup/{DOC_ID}").respond(404, json=error_fixture)
+        mock_api.get(f"/documentgroup/template/{DOC_ID}").respond(404, json=error_fixture)
+        mock_api.get(f"/document/{DOC_ID}").respond(200, json=doc_fixture)
+        mock_api.post(f"/v2/documents/{DOC_ID}/embedded-sending").respond(200, json=sending_fixture)
+
+        result = await _create_embedded_sending(
+            entity_id=DOC_ID,
+            entity_type=None,
+            redirect_uri=None,
+            redirect_target=None,
+            link_expiration_minutes=None,
+            sending_type="manage",
+            token=token,
+            client=sn_client,
+        )
+
+        assert isinstance(result, CreateEmbeddedSendingResponse)
+        assert result.sending_entity == "document"
+        assert result.sending_url == sending_fixture["data"]["url"]
+
+    async def test_non_404_on_group_probe_propagates(
+        self,
+        sn_client: SignNowAPIClient,
+        mock_api: respx.MockRouter,
+        token: str,
+    ) -> None:
+        """entity_type=None → group returns 403 → SignNowAPIAuthenticationError propagates."""
+        mock_api.get(f"/documentgroup/{DOC_ID}").respond(
+            403,
+            json={"errors": [{"code": "403", "message": "Forbidden"}]},
+        )
+
+        with pytest.raises(SignNowAPIAuthenticationError):
+            await _create_embedded_sending(
+                entity_id=DOC_ID,
+                entity_type=None,
+                redirect_uri=None,
+                redirect_target=None,
+                link_expiration_minutes=None,
+                sending_type="manage",
+                token=token,
+                client=sn_client,
+            )

--- a/tests/unit/sn_mcp_server/tools/test_embedded_sending.py
+++ b/tests/unit/sn_mcp_server/tools/test_embedded_sending.py
@@ -6,11 +6,47 @@ import pytest
 
 from signnow_client.exceptions import SignNowAPINotFoundError
 from sn_mcp_server.tools.embedded_sending import (
+    _SENDER_HTML,
+    SENDER_RESOURCE_URI,
     _create_document_embedded_sending,
     _create_document_group_embedded_sending,
     _create_embedded_sending,
 )
 from sn_mcp_server.tools.models import CreateEmbeddedSendingResponse
+
+
+class TestSenderMCPApp:
+    """Test cases for MCP Apps constants and HTML resource."""
+
+    def test_sender_resource_uri_is_correct(self) -> None:
+        """SENDER_RESOURCE_URI matches the expected MCP Apps resource URI."""
+        assert SENDER_RESOURCE_URI == "ui://signnow/embedded-sender"
+
+    def test_sender_html_is_non_empty_string(self) -> None:
+        """_SENDER_HTML is a non-empty string loaded from the static file."""
+        assert isinstance(_SENDER_HTML, str)
+        assert len(_SENDER_HTML) > 0
+
+    def test_sender_html_contains_mcp_apps_handshake(self) -> None:
+        """_SENDER_HTML includes the MCP Apps JSON-RPC 2.0 initialize method."""
+        assert "ui/initialize" in _SENDER_HTML
+        assert "ui/notifications/initialized" in _SENDER_HTML
+
+    def test_sender_html_handles_tool_result_notification(self) -> None:
+        """_SENDER_HTML listens for ui/notifications/tool-result to get the sending URL."""
+        assert "ui/notifications/tool-result" in _SENDER_HTML
+        assert "sending_url" in _SENDER_HTML
+
+    def test_sender_html_uses_correct_storage_key(self) -> None:
+        """_SENDER_HTML uses sn_sender as the sessionStorage key for state recovery."""
+        assert "sn_sender" in _SENDER_HTML
+
+    def test_sender_html_iframe_has_required_sandbox_permissions(self) -> None:
+        """iframe sandbox includes allow-scripts, allow-same-origin, allow-popups, allow-forms."""
+        assert "allow-scripts" in _SENDER_HTML
+        assert "allow-same-origin" in _SENDER_HTML
+        assert "allow-popups" in _SENDER_HTML
+        assert "allow-forms" in _SENDER_HTML
 
 
 class TestCreateDocumentEmbeddedSending:
@@ -22,9 +58,7 @@ class TestCreateDocumentEmbeddedSending:
 
     def test_happy_path_returns_sending_response(self, mock_client: MagicMock) -> None:
         """Successful call returns CreateEmbeddedSendingResponse with sending_entity=document."""
-        mock_client.create_document_embedded_sending.return_value = MagicMock(
-            data=MagicMock(url="https://app.signnow.com/send/doc1")
-        )
+        mock_client.create_document_embedded_sending.return_value = MagicMock(data=MagicMock(url="https://app.signnow.com/send/doc1"))
 
         result = _create_document_embedded_sending(mock_client, "tok", "doc1", None, None, None, "manage")
 
@@ -35,9 +69,7 @@ class TestCreateDocumentEmbeddedSending:
 
     def test_maps_send_invite_type_to_invite(self, mock_client: MagicMock) -> None:
         """sending_type='send-invite' maps to type='invite' in the API request payload."""
-        mock_client.create_document_embedded_sending.return_value = MagicMock(
-            data=MagicMock(url="https://app.signnow.com/send/inv1")
-        )
+        mock_client.create_document_embedded_sending.return_value = MagicMock(data=MagicMock(url="https://app.signnow.com/send/inv1"))
 
         result = _create_document_embedded_sending(mock_client, "tok", "doc1", None, None, None, "send-invite")
 
@@ -57,9 +89,7 @@ class TestCreateDocumentGroupEmbeddedSending:
 
     def test_happy_path_returns_sending_response(self, mock_client: MagicMock) -> None:
         """Successful call returns CreateEmbeddedSendingResponse with sending_entity=document_group."""
-        mock_client.create_document_group_embedded_sending.return_value = MagicMock(
-            data=MagicMock(url="https://app.signnow.com/send/grp1")
-        )
+        mock_client.create_document_group_embedded_sending.return_value = MagicMock(data=MagicMock(url="https://app.signnow.com/send/grp1"))
 
         result = _create_document_group_embedded_sending(mock_client, "tok", "grp1", None, None, None, None)
 
@@ -78,9 +108,7 @@ class TestCreateEmbeddedSending:
 
     async def test_routes_to_document_group_when_explicit_type(self, mock_client: MagicMock) -> None:
         """Explicit entity_type=document_group dispatches to group path; created_entity_* are None."""
-        mock_client.create_document_group_embedded_sending.return_value = MagicMock(
-            data=MagicMock(url="https://app.signnow.com/send/grp")
-        )
+        mock_client.create_document_group_embedded_sending.return_value = MagicMock(data=MagicMock(url="https://app.signnow.com/send/grp"))
 
         result = await _create_embedded_sending("grp1", "document_group", None, None, None, "manage", "tok", mock_client)
 
@@ -93,9 +121,7 @@ class TestCreateEmbeddedSending:
 
     async def test_routes_to_document_when_explicit_type(self, mock_client: MagicMock) -> None:
         """Explicit entity_type=document dispatches to document path; created_entity_* are None."""
-        mock_client.create_document_embedded_sending.return_value = MagicMock(
-            data=MagicMock(url="https://app.signnow.com/send/doc")
-        )
+        mock_client.create_document_embedded_sending.return_value = MagicMock(data=MagicMock(url="https://app.signnow.com/send/doc"))
 
         result = await _create_embedded_sending("doc1", "document", None, None, None, "manage", "tok", mock_client)
 
@@ -109,9 +135,7 @@ class TestCreateEmbeddedSending:
     async def test_auto_detects_document_group(self, mock_client: MagicMock) -> None:
         """entity_type=None auto-detects document_group when get_document_group succeeds."""
         mock_client.get_document_group.return_value = MagicMock()
-        mock_client.create_document_group_embedded_sending.return_value = MagicMock(
-            data=MagicMock(url="https://app.signnow.com/send/auto_grp")
-        )
+        mock_client.create_document_group_embedded_sending.return_value = MagicMock(data=MagicMock(url="https://app.signnow.com/send/auto_grp"))
 
         result = await _create_embedded_sending("grp1", None, None, None, None, "manage", "tok", mock_client)
 
@@ -123,9 +147,7 @@ class TestCreateEmbeddedSending:
         mock_client.get_document_group.side_effect = SignNowAPINotFoundError()
         mock_client.get_document_group_template.side_effect = SignNowAPINotFoundError()
         mock_client.get_document.return_value = MagicMock(template=False)
-        mock_client.create_document_embedded_sending.return_value = MagicMock(
-            data=MagicMock(url="https://app.signnow.com/send/doc_fb")
-        )
+        mock_client.create_document_embedded_sending.return_value = MagicMock(data=MagicMock(url="https://app.signnow.com/send/doc_fb"))
 
         result = await _create_embedded_sending("doc1", None, None, None, None, "manage", "tok", mock_client)
 
@@ -134,13 +156,9 @@ class TestCreateEmbeddedSending:
     async def test_template_creates_doc_then_sends(self, mock_client: MagicMock) -> None:
         """entity_type=template creates document first, then creates sending on new entity."""
         mock_client.create_document_from_template.return_value = MagicMock(id="new_doc", document_name="New Doc")
-        mock_client.create_document_embedded_sending.return_value = MagicMock(
-            data=MagicMock(url="https://app.signnow.com/send/tmpl_doc")
-        )
+        mock_client.create_document_embedded_sending.return_value = MagicMock(data=MagicMock(url="https://app.signnow.com/send/tmpl_doc"))
 
-        result = await _create_embedded_sending(
-            "tmpl1", "template", None, None, None, "manage", "tok", mock_client, name="New Doc"
-        )
+        result = await _create_embedded_sending("tmpl1", "template", None, None, None, "manage", "tok", mock_client, name="New Doc")
 
         assert result.sending_entity == "document"
         assert result.created_entity_id == "new_doc"
@@ -151,13 +169,9 @@ class TestCreateEmbeddedSending:
         mock_client.get_document_template_groups.return_value = MagicMock(document_group_templates=[])
         mock_client.get_document_group_template.return_value = MagicMock(group_name="My Group")
         mock_client.create_document_group_from_template.return_value = MagicMock(data={"unique_id": "new_grp"})
-        mock_client.create_document_group_embedded_sending.return_value = MagicMock(
-            data=MagicMock(url="https://app.signnow.com/send/tg")
-        )
+        mock_client.create_document_group_embedded_sending.return_value = MagicMock(data=MagicMock(url="https://app.signnow.com/send/tg"))
 
-        result = await _create_embedded_sending(
-            "tg1", "template_group", None, None, None, "manage", "tok", mock_client, name="My Group"
-        )
+        result = await _create_embedded_sending("tg1", "template_group", None, None, None, "manage", "tok", mock_client, name="My Group")
 
         assert result.sending_entity == "document_group"
         assert result.created_entity_type == "document_group"
@@ -166,9 +180,7 @@ class TestCreateEmbeddedSending:
         """ctx.report_progress is called 3 times for template flows: 1/3, 2/3, 3/3."""
         ctx = AsyncMock()
         mock_client.create_document_from_template.return_value = MagicMock(id="new_doc2", document_name="Doc2")
-        mock_client.create_document_embedded_sending.return_value = MagicMock(
-            data=MagicMock(url="https://app.signnow.com/send/prog")
-        )
+        mock_client.create_document_embedded_sending.return_value = MagicMock(data=MagicMock(url="https://app.signnow.com/send/prog"))
 
         await _create_embedded_sending("tmpl2", "template", None, None, None, "manage", "tok", mock_client, ctx=ctx)
 


### PR DESCRIPTION
## Summary

Implements SN-30534 — Embedded Sender rendered inline in MCP Apps-compatible hosts (MCP Inspector, VS Code, Goose, LibreChat) without switching browser tabs.

## Changes

### `src/sn_mcp_server/tools/embedded_sending.py`
- Add `SENDER_RESOURCE_URI = "ui://signnow/embedded-sender"` constant
- Pre-load `_SENDER_HTML` from `static/embedded_sender.html` at module load

### `src/sn_mcp_server/tools/signnow.py`
- Add `meta={"ui": {"resourceUri": SENDER_RESOURCE_URI}}` to `create_embedded_sending` tool decorator
- Update tool description to mention MCP Apps inline rendering
- Register `get_embedded_sender_ui()` resource at `ui://signnow/embedded-sender`

### `src/sn_mcp_server/tools/static/embedded_sender.html` _(new)_
- MCP Apps HTML page: JSON-RPC 2.0 handshake, sessionStorage recovery, sandboxed iframe
- 900px height, `sn_sender` storage key, 15s error fallback

### Tests
- `TestSenderMCPApp` unit tests: URI constant, HTML content, MCP Apps protocol markers, iframe sandbox
- Integration tests: `document`, `document_group`, auto-detect (group-first, doc fallback, 403 propagation)
- JSON fixtures: `post_embedded_sending__success.json`, `post_embedded_sending_group__success.json`

## Pattern
Same as `view_document` + `document_viewer.html` — reference implementation for MCP Apps in this repo.