### PR TITLE
fix(tools): accept JSON string for orders in send_invite and create_embedded_invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,10 @@ Each tool is described concisely; use an MCP client (e.g., Inspector) to view ex
 * **`update_document_fields`** — Prefill text fields in individual documents.
 * **`upload_document`** — Upload a document from a local file path (`file_path`), public URL (`file_url`), or MCP resource attachment (`resource_uri`). For `file_path`, the resolved path must stay within the configured safe base directory (by default, the user's home directory); paths outside that base fail validation. Supported: PDF, DOC, DOCX, PNG, JPG, JPEG. Max 40 MB. Returns `document_id`, `filename`, `source`.
 * **`send_invite_reminder`** — Send a signing reminder to pending signers on a document or document group.
+* **`cancel_invite`** — Cancel all active (pending) signing invites on a document or document group. Auto-detects entity type and invite type (field vs freeform). Returns status: `cancelled`, `completed` (already done), or `invite_not_sent`.
+* **`update_invite_recipient`** — Replace the signing recipient on a pending field invite. Finds the pending invite for the current signer and swaps in a new email. Supports both documents and document groups. Only field invites — freeform/embedded are unsupported.
+* **`view_document`** — Generate a read-only embedded view link for a document or document group. In MCP Apps-compatible clients the document renders inline; in other hosts the link is returned as a clickable URL.
+* **`rename_entity`** — Rename a document, document group, template, or template group. Auto-detects entity type when not provided.
 * **`signnow_skills`** — Query the bundled SignNow skill library. Omit `skill_name` to list all available skills with descriptions; provide `skill_name` (e.g. `signnow101`) to fetch the full Markdown body. Use `signnow101` to learn SignNow entity types, invite types, and tool mappings.
   * List mode example: `{"skills": [{"name": "signnow101", "description": "SignNow 101 concepts reference... (description truncated for brevity)"}]}`
   * Fetch mode example: `{"name": "signnow101", "body": "# SignNow 101 — Concepts Reference\n..."}`

--- a/src/sn_mcp_server/tools/signnow.py
+++ b/src/sn_mcp_server/tools/signnow.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import pathlib
 from typing import Annotated, Any, Literal
 from urllib.parse import urlparse
@@ -7,7 +8,7 @@ from fastmcp import Context
 from fastmcp.resources import ResourceContent, ResourceResult
 from fastmcp.server.dependencies import get_http_headers
 from mcp.types import ToolAnnotations
-from pydantic import Field
+from pydantic import Field, TypeAdapter
 
 from signnow_client import SignNowAPIClient
 
@@ -85,6 +86,78 @@ def _get_token_and_client(token_provider: TokenProvider) -> tuple[str, SignNowAP
 
     client = SignNowAPIClient(token_provider.signnow_config)
     return token, client
+
+
+def _normalize_order_field(raw: list[Any]) -> list[Any]:
+    """Ensure each element has an 'order' field, defaulting to position+1 if missing."""
+    for idx, item in enumerate(raw):
+        if isinstance(item, dict) and "order" not in item:
+            item["order"] = idx + 1
+    return raw
+
+
+def _parse_orders(orders: list[InviteOrder] | str | None) -> list[InviteOrder] | None:
+    """Parse invite orders from list or JSON string.
+
+    LLMs sometimes serialize `orders` as a JSON string instead of a native list.
+    This helper transparently coerces the string representation back into typed
+    InviteOrder objects so both forms are accepted by tool endpoints.
+
+    When `order` field is missing from an element, it defaults to position index + 1.
+
+    Args:
+        orders: List of InviteOrder objects, a JSON string, or None.
+
+    Returns:
+        Parsed list of InviteOrder objects, or None if input is None.
+
+    Raises:
+        ValueError: If JSON string cannot be parsed as list[InviteOrder].
+    """
+    if orders is None:
+        return None
+    if isinstance(orders, str):
+        try:
+            raw: Any = json.loads(orders)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid orders JSON string: {exc}") from exc
+        if isinstance(raw, list):
+            _normalize_order_field(raw)
+        adapter: TypeAdapter[list[InviteOrder]] = TypeAdapter(list[InviteOrder])
+        return adapter.validate_python(raw)
+    return orders
+
+
+def _parse_embedded_orders(orders: list[EmbeddedInviteOrder] | str | None) -> list[EmbeddedInviteOrder] | None:
+    """Parse embedded invite orders from list or JSON string.
+
+    LLMs sometimes serialize `orders` as a JSON string instead of a native list.
+    This helper transparently coerces the string representation back into typed
+    EmbeddedInviteOrder objects so both forms are accepted by tool endpoints.
+
+    When `order` field is missing from an element, it defaults to position index + 1.
+
+    Args:
+        orders: List of EmbeddedInviteOrder objects, a JSON string, or None.
+
+    Returns:
+        Parsed list of EmbeddedInviteOrder objects, or None if input is None.
+
+    Raises:
+        ValueError: If JSON string cannot be parsed as list[EmbeddedInviteOrder].
+    """
+    if orders is None:
+        return None
+    if isinstance(orders, str):
+        try:
+            raw: Any = json.loads(orders)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid orders JSON string: {exc}") from exc
+        if isinstance(raw, list):
+            _normalize_order_field(raw)
+        adapter: TypeAdapter[list[EmbeddedInviteOrder]] = TypeAdapter(list[EmbeddedInviteOrder])
+        return adapter.validate_python(raw)
+    return orders
 
 
 def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
@@ -263,9 +336,13 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
         ctx: Context,
         entity_id: Annotated[str, Field(description="ID of the document, document group, template, or template group")],
         orders: Annotated[
-            list[InviteOrder] | None,
+            list[InviteOrder] | str | None,
             Field(
-                description=("List of orders with recipients. Required unless self_sign=True. When self_sign=True, omit orders — the tool fills in the current user as the sole recipient."),
+                description=(
+                    "List of orders with recipients (or a JSON string of the same). "
+                    "Required unless self_sign=True. When self_sign=True, omit orders "
+                    "— the tool fills in the current user as the sole recipient."
+                ),
                 examples=[
                     [{"order": 1, "recipients": [{"email": "user@example.com", "role": "Signer 1", "action": "sign"}]}],
                     [{"order": 1, "recipients": [{"email": "signer@example.com", "action": "sign"}]}],
@@ -338,14 +415,16 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
         """
         token, client = _get_token_and_client(token_provider)
 
+        parsed_orders = _parse_orders(orders)
+
         if self_sign:
-            if orders:
+            if parsed_orders:
                 raise ValueError("orders must be empty when self_sign=True — the tool fills in the current user as the sole recipient")
         else:
-            if not orders:
+            if not parsed_orders:
                 raise ValueError("orders must contain at least one recipient order")
 
-        return await _send_invite(entity_id, entity_type, orders or [], token, client, name, ctx, self_sign=self_sign)
+        return await _send_invite(entity_id, entity_type, parsed_orders or [], token, client, name, ctx, self_sign=self_sign)
 
     @mcp.tool(
         name="create_embedded_invite",
@@ -367,9 +446,9 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
         ctx: Context,
         entity_id: Annotated[str, Field(description="ID of the document, document group, template, or template group")],
         orders: Annotated[
-            list[EmbeddedInviteOrder],
+            list[EmbeddedInviteOrder] | str,
             Field(
-                description="List of orders with recipients.",
+                description="List of orders with recipients (or a JSON string of the same).",
                 examples=[
                     [{"order": 1, "recipients": [{"email": "user@example.com", "role": "Signer 1", "action": "sign", "auth_method": "none"}]}],
                 ],
@@ -401,10 +480,12 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
         """
         token, client = _get_token_and_client(token_provider)
 
-        if not orders:
+        parsed_orders = _parse_embedded_orders(orders)
+
+        if not parsed_orders:
             raise ValueError("orders must contain at least one recipient order")
 
-        return await _create_embedded_invite(entity_id, entity_type, orders, token, client, name, ctx)
+        return await _create_embedded_invite(entity_id, entity_type, parsed_orders, token, client, name, ctx)
 
     @mcp.tool(
         name="create_embedded_sending",

--- a/tests/unit/sn_mcp_server/tools/test_signnow_parse_orders.py
+++ b/tests/unit/sn_mcp_server/tools/test_signnow_parse_orders.py
@@ -1,0 +1,188 @@
+"""Unit tests for _normalize_order_field, _parse_orders, and _parse_embedded_orders in signnow.py."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from sn_mcp_server.tools.models import (
+    EmbeddedInviteOrder,
+    EmbeddedInviteRecipient,
+    InviteOrder,
+    InviteRecipient,
+)
+from sn_mcp_server.tools.signnow import (
+    _normalize_order_field,
+    _parse_embedded_orders,
+    _parse_orders,
+)
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _invite_order(email: str = "signer@example.com", role: str = "Signer 1", order: int = 1) -> InviteOrder:
+    return InviteOrder(order=order, recipients=[InviteRecipient(email=email, role=role)])
+
+
+def _embedded_order(email: str = "signer@example.com", role: str = "Signer 1", order: int = 1) -> EmbeddedInviteOrder:
+    return EmbeddedInviteOrder(order=order, recipients=[EmbeddedInviteRecipient(email=email, role=role)])
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _normalize_order_field
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestNormalizeOrderField:
+    def test_adds_order_when_missing(self) -> None:
+        raw = [{"recipients": [{"email": "a@b.com"}]}]
+        _normalize_order_field(raw)
+        assert raw[0]["order"] == 1
+
+    def test_preserves_existing_order(self) -> None:
+        raw = [{"order": 5, "recipients": [{"email": "a@b.com"}]}]
+        _normalize_order_field(raw)
+        assert raw[0]["order"] == 5
+
+    def test_multiple_items_auto_numbered(self) -> None:
+        raw = [{"recipients": []}, {"recipients": []}, {"recipients": []}]
+        _normalize_order_field(raw)
+        assert [item["order"] for item in raw] == [1, 2, 3]
+
+    def test_mixed_present_and_missing(self) -> None:
+        raw = [{"order": 10, "recipients": []}, {"recipients": []}]
+        _normalize_order_field(raw)
+        assert raw[0]["order"] == 10  # preserved
+        assert raw[1]["order"] == 2  # filled from index
+
+    def test_empty_list(self) -> None:
+        raw: list = []
+        _normalize_order_field(raw)
+        assert raw == []
+
+    def test_non_dict_items_skipped(self) -> None:
+        """Non-dict items are left untouched (Pydantic will reject them later)."""
+        raw: list = ["not a dict"]
+        _normalize_order_field(raw)
+        assert raw == ["not a dict"]
+
+    def test_returns_same_list(self) -> None:
+        raw = [{"recipients": []}]
+        result = _normalize_order_field(raw)
+        assert result is raw
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _parse_orders
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestParseOrders:
+    def test_none_returns_none(self) -> None:
+        assert _parse_orders(None) is None
+
+    def test_list_passthrough(self) -> None:
+        orders = [_invite_order()]
+        assert _parse_orders(orders) is orders
+
+    def test_valid_json_string_with_order_field(self) -> None:
+        data = [{"order": 1, "recipients": [{"email": "a@b.com", "role": "Signer 1"}]}]
+        result = _parse_orders(json.dumps(data))
+        assert result is not None
+        assert len(result) == 1
+        assert isinstance(result[0], InviteOrder)
+        assert result[0].order == 1
+        assert result[0].recipients[0].email == "a@b.com"
+
+    def test_json_string_without_order_field_auto_fills(self) -> None:
+        """LLM sometimes omits 'order'; should be auto-filled from position."""
+        data = [{"recipients": [{"email": "tymoshenko.anna@airslate.com", "role": "Recipient 1"}]}]
+        result = _parse_orders(json.dumps(data))
+        assert result is not None
+        assert result[0].order == 1
+        assert result[0].recipients[0].email == "tymoshenko.anna@airslate.com"
+
+    def test_json_string_multiple_orders_auto_numbered(self) -> None:
+        data = [
+            {"recipients": [{"email": "a@a.com", "role": "R1"}]},
+            {"recipients": [{"email": "b@b.com", "role": "R2"}]},
+        ]
+        result = _parse_orders(json.dumps(data))
+        assert result is not None
+        assert result[0].order == 1
+        assert result[1].order == 2
+
+    def test_invalid_json_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Invalid orders JSON string"):
+            _parse_orders("{bad json")
+
+    def test_invalid_schema_raises(self) -> None:
+        """Valid JSON but recipients field missing — Pydantic should reject."""
+        with pytest.raises(ValidationError):
+            _parse_orders(json.dumps([{"order": 1}]))
+
+    def test_returns_typed_invite_order_instances(self) -> None:
+        data = [{"recipients": [{"email": "x@x.com", "role": "Signer"}]}]
+        result = _parse_orders(json.dumps(data))
+        assert result is not None
+        assert isinstance(result[0], InviteOrder)
+        assert isinstance(result[0].recipients[0], InviteRecipient)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _parse_embedded_orders
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestParseEmbeddedOrders:
+    def test_none_returns_none(self) -> None:
+        assert _parse_embedded_orders(None) is None
+
+    def test_list_passthrough(self) -> None:
+        orders = [_embedded_order()]
+        assert _parse_embedded_orders(orders) is orders
+
+    def test_valid_json_string_with_order_field(self) -> None:
+        data = [{"order": 1, "recipients": [{"email": "a@b.com", "role": "Signer 1", "action": "sign"}]}]
+        result = _parse_embedded_orders(json.dumps(data))
+        assert result is not None
+        assert len(result) == 1
+        assert isinstance(result[0], EmbeddedInviteOrder)
+        assert result[0].order == 1
+        assert result[0].recipients[0].email == "a@b.com"
+
+    def test_json_string_without_order_field_auto_fills(self) -> None:
+        data = [{"recipients": [{"email": "e@e.com", "role": "Recipient 1"}]}]
+        result = _parse_embedded_orders(json.dumps(data))
+        assert result is not None
+        assert result[0].order == 1
+        assert result[0].recipients[0].email == "e@e.com"
+
+    def test_json_string_multiple_orders_auto_numbered(self) -> None:
+        data = [
+            {"recipients": [{"email": "a@a.com", "role": "R1"}]},
+            {"recipients": [{"email": "b@b.com", "role": "R2"}]},
+        ]
+        result = _parse_embedded_orders(json.dumps(data))
+        assert result is not None
+        assert result[0].order == 1
+        assert result[1].order == 2
+
+    def test_invalid_json_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Invalid orders JSON string"):
+            _parse_embedded_orders("not json at all")
+
+    def test_invalid_schema_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _parse_embedded_orders(json.dumps([{"order": 1}]))
+
+    def test_returns_typed_embedded_order_instances(self) -> None:
+        data = [{"recipients": [{"email": "x@x.com", "role": "Signer"}]}]
+        result = _parse_embedded_orders(json.dumps(data))
+        assert result is not None
+        assert isinstance(result[0], EmbeddedInviteOrder)
+        assert isinstance(result[0].recipients[0], EmbeddedInviteRecipient)


### PR DESCRIPTION
## Problem

LLMs sometimes serialize the `orders` parameter as a JSON string instead of a native list. For example:

```json
{
  "entity_id": "5eeb884c...",
  "entity_type": "document",
  "orders": "[{\"recipients\":[{\"email\":\"user@example.com\",\"role\":\"Recipient 1\"}]}]",
  "preview_was_shown": "false"
}
```

This caused a `ValidationError` in both `send_invite` (v2) and `create_embedded_invite` (v2) because the type annotation only accepted `list[InviteOrder]`. Additionally, LLMs often omit the `order` field entirely, which Pydantic also rejected.

## Solution

Added three helpers to `signnow.py`:

- **`_normalize_order_field(raw)`** — iterates the raw list and fills in a missing `order` field using the element's index + 1. This handles the common LLM pattern of omitting `order` when there's only one step.
- **`_parse_orders(orders)`** — accepts `list[InviteOrder] | str | None`; JSON-decodes string input, runs normalization, then validates with `TypeAdapter`. Lists and `None` pass through unchanged.
- **`_parse_embedded_orders(orders)`** — same for `list[EmbeddedInviteOrder] | str | None`.

Both `send_invite` and `create_embedded_invite` (v2) now call these helpers before validation.

## Changes

| File | Change |
|------|--------|
| `src/sn_mcp_server/tools/signnow.py` | Added `_normalize_order_field`, `_parse_orders`, `_parse_embedded_orders`; updated both tool handlers to use them; widened type hints to `list[...] \| str` |
| `README.md` | Added missing tools: `cancel_invite`, `update_invite_recipient`, `view_document`, `rename_entity` |
| `tests/unit/.../test_signnow_parse_orders.py` | 23 new unit tests covering all three helpers |

## Tests

```
23 passed in 1.42s
```

All pre-push hooks pass (ruff-format, ruff, pytest unit+integration+api, import-linter).