### PR TITLE
Restrict EmbeddedInviteAuthentication.type to Literal['phone', 'password']

### DIFF
--- a/src/signnow_client/models/templates_and_documents.py
+++ b/src/signnow_client/models/templates_and_documents.py
@@ -6,7 +6,7 @@ Pydantic models for SignNow API responses and requests related to templates and 
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, model_validator
 
@@ -843,7 +843,10 @@ class CancelDocumentFreeformInviteRequest(BaseModel):
 class EmbeddedInviteAuthentication(BaseModel):
     """Authentication settings for embedded invite signer."""
 
-    type: str = Field(..., description="Authentication type: 'phone' or 'password'")
+    type: Literal["phone", "password"] = Field(
+        ...,
+        description="Authentication type. Only 'phone' or 'password' are allowed. Other values (e.g. 'email', 'mfa') are not supported for signer identity verification.",
+    )
     password: str | None = Field(None, description="Password for password authentication")
     method: str | None = Field(None, description="Method for phone authentication: 'sms' or 'phone_call'")
     phone: str | None = Field(None, description="Phone number for phone authentication")

--- a/tests/unit/signnow_client/test_embedded_invite_auth.py
+++ b/tests/unit/signnow_client/test_embedded_invite_auth.py
@@ -1,0 +1,36 @@
+"""Unit tests for EmbeddedInviteAuthentication type validation."""
+
+import pytest
+from pydantic import ValidationError
+
+from signnow_client.models.templates_and_documents import EmbeddedInviteAuthentication
+
+
+class TestEmbeddedInviteAuthenticationType:
+    """Test cases for EmbeddedInviteAuthentication type field validation."""
+
+    def test_password_type_accepted(self) -> None:
+        """Test 'password' is a valid authentication type."""
+        auth = EmbeddedInviteAuthentication(type="password", password="s3cr3t")  # noqa: S106
+        assert auth.type == "password"
+
+    def test_phone_type_accepted(self) -> None:
+        """Test 'phone' is a valid authentication type."""
+        auth = EmbeddedInviteAuthentication(type="phone", phone="+1234567890", method="sms")
+        assert auth.type == "phone"
+
+    def test_invalid_type_raises_validation_error(self) -> None:
+        """Test invalid type like 'email' raises ValidationError with clear message."""
+        with pytest.raises(ValidationError, match="phone.*password|password.*phone"):
+            EmbeddedInviteAuthentication(type="email")
+
+    def test_empty_type_raises_validation_error(self) -> None:
+        """Test empty string type raises ValidationError."""
+        with pytest.raises(ValidationError, match="phone.*password|password.*phone"):
+            EmbeddedInviteAuthentication(type="")
+
+    @pytest.mark.parametrize("invalid_type", ["mfa", "biometric", "social", "none", "EMAIL", "Phone"])
+    def test_various_invalid_types_rejected(self, invalid_type: str) -> None:
+        """Test various invalid type values are rejected."""
+        with pytest.raises(ValidationError):
+            EmbeddedInviteAuthentication(type=invalid_type)


### PR DESCRIPTION
## Summary

`EmbeddedInviteAuthentication.type` previously accepted any string, allowing invalid values like `'email'` to pass Pydantic validation silently. This change restricts the field to `Literal["phone", "password"]` so that unsupported types produce a clear `ValidationError`.

## Changes

- **`src/signnow_client/models/templates_and_documents.py`** — Changed `EmbeddedInviteAuthentication.type` from `str` to `Literal["phone", "password"]` with an explicit description listing supported values.
- **`tests/unit/signnow_client/test_embedded_invite_auth.py`** — Added unit tests ensuring valid types pass, invalid types (email, mfa, biometric, etc.) raise `ValidationError`, and edge cases like empty strings are rejected.

## Tests

10 unit tests added covering:
- Valid types (`password`, `phone`) accepted
- Invalid type (`email`) produces `ValidationError` with clear message
- Empty string rejected
- Parametrized coverage for `mfa`, `biometric`, `social`, `none`, `EMAIL`, `Phone`