### PR TITLE
Add per-request access token via X-SignNow-Access-Token header

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,25 @@ SIGNNOW_CLIENT_SECRET=<client_secret>
 
 > When running via some desktop clients, only user/password may be supported.
 
+#### Per-request access token (HTTP transport)
+
+For multi-tenant / proxy deployments, a wrapping backend can attach the **raw SignNow
+access token per request** via a dedicated HTTP header — no env config, and without
+reusing `Authorization` (which carries the MCP/OAuth bearer):
+
+```
+X-SignNow-Access-Token: <raw SignNow access_token>
+```
+
+- Value is the **raw token** — no `Bearer ` prefix.
+- Resolved per request; nothing is cached or stored (stateless).
+- **Precedence:** an env-configured `SIGNNOW_ACCESS_TOKEN` (Option 1) still wins. To use
+  the header as a true per-request credential, do **not** also set `SIGNNOW_ACCESS_TOKEN`
+  — otherwise every request collapses to the env token. The header outranks a generic
+  `Authorization: Bearer`.
+- HTTP transport only (`sn-mcp http`). It is **not** exposed as a tool argument, so the
+  token never enters the model's context or conversation logs. Send over HTTPS.
+
 ### SignNow & OAuth settings
 
 ```

--- a/src/sn_mcp_server/token_provider.py
+++ b/src/sn_mcp_server/token_provider.py
@@ -3,6 +3,13 @@ from signnow_client.config import load_signnow_config
 
 from .config import load_settings
 
+# Dedicated per-request header carrying the RAW SignNow access token.
+# Kept distinct from `Authorization` — which carries the MCP-issued/OAuth-proxy
+# bearer (the "MCP JWT") — so a programmatic caller can supply a SignNow token
+# per request without colliding with the MCP auth layer. Read lowercased:
+# both get_http_headers() and dict(request.headers) normalise names to lowercase.
+SIGNNOW_ACCESS_TOKEN_HEADER = "x-signnow-access-token"  # noqa: S105 — HTTP header NAME, not a secret value
+
 
 class TokenProvider:
     """Automatically provides access tokens from config credentials or authorization headers"""
@@ -61,6 +68,14 @@ class TokenProvider:
         """Extract token from request headers, checking multiple possible locations"""
         if not headers:
             return None
+
+        # Dedicated SignNow token header wins over the generic Authorization
+        # bearer: Authorization may carry the MCP JWT (not a SignNow token), so an
+        # explicit X-SignNow-Access-Token is the unambiguous per-request override.
+        # Value is the RAW token — no "Bearer " prefix to strip.
+        signnow_token = (headers.get(SIGNNOW_ACCESS_TOKEN_HEADER) or "").strip()
+        if signnow_token:
+            return signnow_token
 
         # Try authorization header first
         auth_header = headers.get("authorization", "")

--- a/src/sn_mcp_server/tools/signnow.py
+++ b/src/sn_mcp_server/tools/signnow.py
@@ -12,7 +12,7 @@ from pydantic import Field, TypeAdapter
 
 from signnow_client import SignNowAPIClient
 
-from ..token_provider import TokenProvider
+from ..token_provider import SIGNNOW_ACCESS_TOKEN_HEADER, TokenProvider
 from .cancel_invite import _cancel_invite
 from .create_from_template import _create_from_template
 from .create_template import create_template as _create_template
@@ -78,7 +78,10 @@ def _get_token_and_client(token_provider: TokenProvider) -> tuple[str, SignNowAP
     Raises:
         ValueError: If no access token is available
     """
-    headers = get_http_headers(include={"authorization"})
+    # `x-signnow-access-token` is not in get_http_headers()'s default exclude set,
+    # so it already passes through; listed here to document the contract at the
+    # auth seam and stay robust if it's ever added to the exclude set.
+    headers = get_http_headers(include={"authorization", SIGNNOW_ACCESS_TOKEN_HEADER})
     token = token_provider.get_access_token(headers)
 
     if not token:

--- a/tests/unit/sn_mcp_server/test_token_provider.py
+++ b/tests/unit/sn_mcp_server/test_token_provider.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from sn_mcp_server.token_provider import TokenProvider
 
 
@@ -103,3 +105,53 @@ class TestGetAccessTokenStaticToken:
         """Returns None when static token, credentials, and headers are all absent."""
         provider = _make_provider_with_static_token(access_token=None)
         assert provider.get_access_token() is None
+
+
+class TestSignNowAccessTokenHeader:
+    """Per-request X-SignNow-Access-Token header (HTTP transport, raw SignNow token).
+
+    Pins the FULL precedence ladder. The first row is the precedence decision made
+    explicit: env static token (Option C) still wins over the per-request header.
+    Flipping that single expected value (and test_static_token_wins_over_authorization_header)
+    is the only change needed to switch to a "per-request wins" policy.
+    """
+
+    @pytest.mark.parametrize(
+        ("static", "creds_response", "headers", "expected"),
+        [
+            # env static token beats the new header — preserves the Option C invariant
+            ("static_tok", None, {"x-signnow-access-token": "hdr_tok", "authorization": "Bearer auth_tok"}, "static_tok"),
+            # password grant beats the new header
+            (None, "oauth_tok", {"x-signnow-access-token": "hdr_tok"}, "oauth_tok"),
+            # dedicated header beats the generic Authorization bearer
+            (None, None, {"x-signnow-access-token": "hdr_tok", "authorization": "Bearer auth_tok"}, "hdr_tok"),
+            # raw token returned verbatim — no "Bearer " stripping
+            (None, None, {"x-signnow-access-token": "raw_sn_tok"}, "raw_sn_tok"),
+            # whitespace-only header is ignored, falls through to Authorization
+            (None, None, {"x-signnow-access-token": "   ", "authorization": "Bearer auth_tok"}, "auth_tok"),
+        ],
+    )
+    def test_signnow_token_header_precedence(
+        self,
+        static: str | None,
+        creds_response: str | None,
+        headers: dict[str, str],
+        expected: str,
+    ) -> None:
+        provider = _make_provider_with_static_token(
+            access_token=static,
+            email="u@e.com" if creds_response else None,
+            pwd="pw" if creds_response else None,  # noqa: S106
+            api_response={"access_token": creds_response} if creds_response else None,
+        )
+        assert provider.get_access_token(headers) == expected
+
+    def test_header_only_request_yields_token_for_presence_gate(self) -> None:
+        """The /mcp 401 gate (auth.py) calls get_access_token(dict(request.headers)).
+
+        A request carrying only X-SignNow-Access-Token (no config creds) must yield a
+        token so the gate admits it — this is what lets a bring-your-own-token caller
+        reach the tools over HTTP.
+        """
+        provider = _make_provider_with_static_token(access_token=None)
+        assert provider.get_access_token({"x-signnow-access-token": "tenant_tok"}) == "tenant_tok"


### PR DESCRIPTION
## Summary

Adds a per-request way to supply the **raw SignNow access token** over HTTP — for programmatic/multi-tenant callers (e.g. a backend proxy) that want to bring their own token per request and bypass the self-issued MCP JWT, without any env configuration. Complements the existing env-level static token (Option C) with a request-scoped channel.

The token already flows per call as a plain `str` into every `signnow_client` method (which builds `Authorization: Bearer <token>` itself), so this only adds a **new source in `TokenProvider`** — the client and tool/business-logic layers are untouched. Stays fully stateless (nothing cached or stored).

## Changes

- **`token_provider.py`** — new dedicated header `X-SignNow-Access-Token` (constant `SIGNNOW_ACCESS_TOKEN_HEADER`), resolved as the **first** header source in `_extract_token_from_headers`. Value is the raw token (no `Bearer ` prefix); blank/whitespace falls through. Kept distinct from `Authorization`, which carries the MCP JWT / OAuth-proxy bearer — so it's unambiguous which token is the SignNow one.
- **`tools/signnow.py`** — surface the header at the `_get_token_and_client` auth seam (also documents the contract; the header isn't in `get_http_headers()`'s default exclude set, so it already passes through).
- **README** — documents the header: HTTP transport only, raw token, send over HTTPS, never a tool argument (stays out of the LLM context/logs).

## Precedence (additive — no behavior change for existing setups)

```
1. env SIGNNOW_ACCESS_TOKEN (Option C)   ← unchanged, highest
2. password grant (env)                  ← unchanged
3. X-SignNow-Access-Token  (NEW)         ← outranks only the generic Authorization Bearer
4. Authorization: Bearer
5. legacy x-access-token / x-auth-token / token
```

An env-pinned `SIGNNOW_ACCESS_TOKEN` still wins, so a stray client header can't override an operator's pin. To use the header as a true per-request credential, **do not also set** `SIGNNOW_ACCESS_TOKEN` (otherwise every request collapses to the env token). The `/mcp` 401 gate (`auth.py`) admits a header-only request automatically — it already feeds `dict(request.headers)` into the same `get_access_token`.

## Tests

- Parametrized invariant pinning the **full precedence ladder** (`TestSignNowAccessTokenHeader`), including env-static-wins, raw-token-verbatim, and whitespace-fallthrough rows. Flipping the first row is the single change needed to switch to a "per-request wins" policy later.
- Header-only presence-gate case (a request carrying only `X-SignNow-Access-Token`, no config creds, yields a token).
- All checks pass against the working tree: `ruff`, `ruff format`, `mypy src/`, and unit suite (728 passed, 1 pre-existing skip).

> Note: the local pre-commit `pytest` hook imports a stale non-editable copy of `sn_mcp_server` from site-packages (the editable record points at a different checkout), so it ran the new tests against old code and false-negatived. Verified green via `PYTHONPATH=src python -m pytest`. CI installs editable from the checkout, so it validates the real code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)