### PR TITLE
Constrain embedded invite enum fields to Literal types

### DIFF
--- a/src/sn_mcp_server/tools/models.py
+++ b/src/sn_mcp_server/tools/models.py
@@ -663,17 +663,17 @@ class EmbeddedInviteRecipient(BaseModel):
 
     email: str = Field(..., description="Recipient's email address")
     role: str = Field(..., description="Recipient's role name in the document")
-    action: str = Field(default="sign", description="Allowed action with a document. Possible values: 'view', 'sign', 'approve'")
-    auth_method: str = Field("none", description="Authentication method in integrated app: 'password', 'email', 'mfa', 'biometric', 'social', 'other', 'none'")
+    action: Literal["view", "sign", "approve"] = Field(default="sign", description="Allowed action with a document. Possible values: 'view', 'sign', 'approve'")
+    auth_method: Literal["password", "email", "mfa", "biometric", "social", "other", "none"] = Field("none", description="Authentication method in integrated app")
     first_name: str | None = Field(None, description="Recipient's first name")
     last_name: str | None = Field(None, description="Recipient's last name")
     redirect_uri: str | None = Field(None, description="Link that opens after completion")
     decline_redirect_uri: str | None = Field(None, description="URL that opens after decline")
     close_redirect_uri: str | None = Field(None, description="Link that opens when clicking 'Close' button")
-    redirect_target: str | None = Field("self", description="Redirect target: 'blank' for new tab, 'self' for same tab")
+    redirect_target: Literal["blank", "self"] | None = Field("self", description="Redirect target: 'blank' for new tab, 'self' for same tab")
     subject: str | None = Field(None, description="Invite email subject (max 1000 chars)")
     message: str | None = Field(None, description="Invite email message (max 5000 chars)")
-    delivery_type: str | None = Field("link", description="Invite delivery method: 'email' or 'link', use 'link' if you wand to get a link to sign. If you want to send an email, use 'email'")
+    delivery_type: Literal["email", "link"] | None = Field("link", description="Invite delivery method: use 'link' if you want to get a link to sign, use 'email' to send an email")
 
     def model_dump(self, **kwargs: Any) -> dict[str, Any]:  # noqa: ANN401
         """Override model_dump to exclude redirect_target if redirect_uri is not provided."""

--- a/tests/unit/sn_mcp_server/tools/test_embedded_invite.py
+++ b/tests/unit/sn_mcp_server/tools/test_embedded_invite.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 from signnow_client.exceptions import SignNowAPINotFoundError
 from sn_mcp_server.tools.embedded_invite import (
@@ -189,3 +190,25 @@ class TestCreateEmbeddedInvite:
         result = await _create_embedded_invite("tg_auto", None, [_make_order()], "tok", mock_client, name="My Group")
 
         assert result.created_entity_type == "document_group"
+
+
+class TestEmbeddedInviteRecipientValidation:
+    """Test cases for EmbeddedInviteRecipient enum field validation."""
+
+    @pytest.mark.parametrize(
+        ("field", "allowed"),
+        [
+            ("action", "'view', 'sign' or 'approve'"),
+            ("auth_method", "'password', 'email', 'mfa', 'biometric', 'social', 'other' or 'none'"),
+            ("redirect_target", "'blank' or 'self'"),
+            ("delivery_type", "'email' or 'link'"),
+        ],
+    )
+    def test_invalid_value_error_lists_allowed_values(self, field: str, allowed: str) -> None:
+        """Invalid enum value raises ValidationError that names the field and its allowed values."""
+        with pytest.raises(ValidationError) as exc_info:
+            EmbeddedInviteRecipient(email="signer@example.com", role="Signer", **{field: "bogus"})
+
+        error_text = str(exc_info.value)
+        assert field in error_text
+        assert allowed in error_text

--- a/tests/unit/sn_mcp_server/tools/test_embedded_invite.py
+++ b/tests/unit/sn_mcp_server/tools/test_embedded_invite.py
@@ -198,17 +198,21 @@ class TestEmbeddedInviteRecipientValidation:
     @pytest.mark.parametrize(
         ("field", "allowed"),
         [
-            ("action", "'view', 'sign' or 'approve'"),
-            ("auth_method", "'password', 'email', 'mfa', 'biometric', 'social', 'other' or 'none'"),
-            ("redirect_target", "'blank' or 'self'"),
-            ("delivery_type", "'email' or 'link'"),
+            ("action", ("view", "sign", "approve")),
+            ("auth_method", ("password", "email", "mfa", "biometric", "social", "other", "none")),
+            ("redirect_target", ("blank", "self")),
+            ("delivery_type", ("email", "link")),
         ],
     )
-    def test_invalid_value_error_lists_allowed_values(self, field: str, allowed: str) -> None:
+    def test_invalid_value_error_lists_allowed_values(self, field: str, allowed: tuple[str, ...]) -> None:
         """Invalid enum value raises ValidationError that names the field and its allowed values."""
         with pytest.raises(ValidationError) as exc_info:
             EmbeddedInviteRecipient(email="signer@example.com", role="Signer", **{field: "bogus"})
 
-        error_text = str(exc_info.value)
-        assert field in error_text
-        assert allowed in error_text
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        error = errors[0]
+        assert error["type"] == "literal_error"
+        assert error["loc"] == (field,)
+        for value in allowed:
+            assert f"'{value}'" in error["msg"]


### PR DESCRIPTION
## Summary
Recipient enum-like fields on `EmbeddedInviteRecipient` (`auth_method`, `delivery_type`, `action`, `redirect_target`) were plain strings with allowed values listed only in prose descriptions. Invalid values passed Pydantic validation and reached the SignNow API. This change constrains them to `Literal` types so the allowed values appear as `enum` in the MCP tool JSON schema for `create_embedded_invite`, and invalid input is rejected with a validation error that names the valid choices.

## Changes
- `auth_method` → `Literal["password", "email", "mfa", "biometric", "social", "other", "none"]`
- `delivery_type` → `Literal["email", "link"] | None`
- `action` → `Literal["view", "sign", "approve"]`
- `redirect_target` → `Literal["blank", "self"] | None`
- Dropped value enumerations from descriptions now covered by the schema enum
- Fixed a `wand` → `want` typo in the `delivery_type` description

## Tests
Added `TestEmbeddedInviteRecipientValidation` — parametrized over all four fields, asserts an invalid value raises `ValidationError` whose message names the field and lists the allowed values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)