### PR TITLE
Return folder info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ extend-exclude = ["src/sn_mcp_server/_version.py"]
 "tests/unit/sn_mcp_server/test_tool_versions.py" = ["S101", "ANN401"]
 "tests/unit/sn_mcp_server/tools/test_signnow_v1.py" = ["S101", "ANN401"]
 "tests/unit/sn_mcp_server/tools/test_create_from_template.py" = ["S101", "ANN401"]
+"tests/unit/sn_mcp_server/tools/test_document.py" = ["S101", "ANN401"]
 "src/sn_mcp_server/auth.py" = ["S101"] # unreachable type-narrowing asserts; see auth.py:181,191,230
 # Pydantic field_validator(mode="before") helpers normalize raw API payloads of unknown shape;
 # Any is the correct input type — the helper's job is to narrow it to a concrete type.

--- a/src/signnow_client/client_documents.py
+++ b/src/signnow_client/client_documents.py
@@ -148,7 +148,7 @@ class DocumentClientMixin(SignNowAPIClientBase):
         except Exception as e:
             raise SignNowAPIError(f"Unexpected error in prefill_text_fields request: {e}") from e
 
-    def get_document(self, token: str, document_id: str) -> DocumentResponse:
+    def get_document(self, token: str, document_id: str, is_custom_folder: bool = False) -> DocumentResponse:
         """
         Get document details.
 
@@ -158,15 +158,17 @@ class DocumentClientMixin(SignNowAPIClientBase):
         Args:
             token: Access token for authentication
             document_id: ID of the document to retrieve
-            include_integration_objects: Include smart fields in response
+            is_custom_folder: When True, ``parent_id`` is the document's immediate
+                (possibly nested) folder instead of the top-level system folder.
 
         Returns:
             Validated DocumentResponse model with complete document information
         """
 
         headers = {"Accept": "application/json", "Authorization": f"Bearer {token}"}
+        params = {"is_custom_folder": "true"} if is_custom_folder else None
 
-        return self._get(f"/document/{document_id}", headers=headers, validate_model=DocumentResponse)
+        return self._get(f"/document/{document_id}", headers=headers, params=params, validate_model=DocumentResponse)
 
     def merge_documents(self, token: str, request_data: MergeDocumentsRequest) -> MergeDocumentsResponse:
         """

--- a/src/signnow_client/client_other.py
+++ b/src/signnow_client/client_other.py
@@ -207,6 +207,30 @@ class OtherClientMixin(SignNowAPIClientBase):
 
         return self._get(f"/folder/{folder_id}", headers=headers, params=params, validate_model=GetFolderByIdResponseLite)
 
+    def get_folder_tree(self, token: str) -> GetFoldersResponseLite:
+        """Get the full nested folder hierarchy for a user in a single call.
+
+        Plain ``get_folders`` returns only the root and its top-level folders. The
+        ``/v1/folder`` root endpoint, given ``subfolder-data=1`` together with
+        ``include_documents_subfolders=1`` (the API requires both, and they are 1/0
+        flags), returns every descendant recursively via the ``sub_folders`` field —
+        including team folder subfolders, which the plain ``/user/folder`` tree omits.
+
+        Args:
+            token: Access token for authentication
+
+        Returns:
+            GetFoldersResponseLite whose ``folders`` carry nested ``sub_folders``
+        """
+
+        headers = {"Accept": "application/json", "Authorization": f"Bearer {token}"}
+        params: dict[str, Any] = {
+            "subfolder-data": 1,
+            "include_documents_subfolders": 1,
+            "with_team_documents": "true",
+        }
+        return self._get("/v1/folder", headers=headers, params=params, validate_model=GetFoldersResponseLite)
+
     def get_user_info(self, token: str) -> User:
         """
         Get user information from SignNow API.

--- a/src/signnow_client/models/document_groups.py
+++ b/src/signnow_client/models/document_groups.py
@@ -329,6 +329,7 @@ class DocumentGroupV2Data(BaseModel):
 
     id: str = Field(..., description="Document group ID")
     name: str = Field(..., description="Document group name")
+    folder_id: str | None = Field(None, description="ID of the folder the document group is stored in")
     created: int = Field(..., description="Unix timestamp when group was created")
     invite_id: str | None = Field(None, description="Current invite ID")
     pending_step_id: str | None = Field(None, description="ID of the pending step")
@@ -389,6 +390,7 @@ class GetDocumentGroupTemplateResponse(BaseModel):
 
     id: str = Field(..., description="Document group template ID")
     group_name: str = Field(..., description="Name of the template group")
+    folder_id: str | None = Field(None, description="ID of the folder the template group is stored in")
     templates: list[TemplateShort] = Field(..., description="List of templates in this group")
 
 

--- a/src/signnow_client/models/folders_lite.py
+++ b/src/signnow_client/models/folders_lite.py
@@ -328,6 +328,11 @@ class FolderLite(SNBaseModel):
     team_id: str | None = None
     team_type: str | None = None
 
+    # Nested subfolders — populated only when the folder listing is requested with
+    # subfolder-data=1 & include_documents_subfolders=1, which returns the hierarchy
+    # recursively. Empty on the plain get_folders listing.
+    sub_folders: list[FolderLite] = Field(default_factory=list)
+
 
 class GetFoldersResponseLite(SNBaseModel):
     id: str

--- a/src/sn_mcp_server/tools/document.py
+++ b/src/sn_mcp_server/tools/document.py
@@ -14,6 +14,7 @@ from signnow_client.models.document_groups import (
     GetDocumentGroupTemplateResponse,
     GetDocumentGroupV2Response,
 )
+from signnow_client.models.folders_lite import FolderLite
 from signnow_client.models.templates_and_documents import (
     CreateDocumentFromUrlRequest,
     DocumentResponse,
@@ -238,7 +239,16 @@ def _get_full_document(client: SignNowAPIClient, token: str, document_id: str, d
                 )
             )
 
-    return DocumentGroupDocument(id=document_response.id, name=document_response.document_name, roles=[role.name for role in document_response.roles], fields=document_fields)
+    # `parent_id` is the document's immediate folder (requires is_custom_folder on the
+    # GET /document call, else it's the top-level folder). folder_name is resolved
+    # separately (one get_folder_tree call) by _resolve_folder_names.
+    return DocumentGroupDocument(
+        id=document_response.id,
+        name=document_response.document_name,
+        folder_id=document_response.parent_id,
+        roles=[role.name for role in document_response.roles],
+        fields=document_fields,
+    )
 
 
 def _get_full_document_group(client: SignNowAPIClient, token: str, group_data: GetDocumentGroupV2Response) -> DocumentGroup:
@@ -265,7 +275,7 @@ def _get_full_document_group(client: SignNowAPIClient, token: str, group_data: G
     for doc in data.documents:
         if doc.field_invites:
             all_field_invites.extend(doc.field_invites)
-        document_data = client.get_document(token, doc.id)
+        document_data = client.get_document(token, doc.id, is_custom_folder=True)
         full_doc = _get_full_document(client=client, token=token, document_id=doc.id, document_data=document_data)
         full_documents.append(full_doc)
 
@@ -284,6 +294,7 @@ def _get_full_document_group(client: SignNowAPIClient, token: str, group_data: G
         entity_id=data.id,
         group_name=data.name,
         entity_type="document_group",
+        folder_id=data.folder_id,
         invite=invite,
         freeform_invite_id=freeform_invite_id,
         documents=full_documents,
@@ -310,8 +321,12 @@ def _get_full_template_group(client: SignNowAPIClient, token: str, template_grou
     full_documents = []
     for template in template_group_data.templates:
         # Get template data as document (templates are documents in SignNow)
-        document_data = client.get_document(token, template.id)
+        document_data = client.get_document(token, template.id, is_custom_folder=True)
         full_doc = _get_full_document(client=client, token=token, document_id=template.id, document_data=document_data)
+        # A template group's member templates report no folder of their own; the folder is a
+        # group-level property, so surface it on each member for folder-name resolution.
+        if full_doc.folder_id is None:
+            full_doc.folder_id = template_group_data.folder_id
         full_documents.append(full_doc)
 
     # Create DocumentGroup with full template information
@@ -320,12 +335,57 @@ def _get_full_template_group(client: SignNowAPIClient, token: str, template_grou
         entity_id=template_group_data.id,
         group_name=template_group_data.group_name,
         entity_type="template_group",
+        folder_id=template_group_data.folder_id,
         invite=None,  # Not applicable for template groups
         documents=full_documents,
     )
 
 
-def _get_document(client: SignNowAPIClient, token: str, entity_id: str, entity_type: Literal["document", "document_group", "template", "template_group"] | None = None) -> DocumentGroup:
+def _index_folder_tree(folders: list[FolderLite], name_by_id: dict[str, str]) -> None:
+    """Record ``id → name`` for every folder in a nested listing, recursing into ``sub_folders``."""
+    for folder in folders:
+        name_by_id[folder.id] = folder.name
+        if folder.sub_folders:
+            _index_folder_tree(folder.sub_folders, name_by_id)
+
+
+def _resolve_folder_names(client: SignNowAPIClient, token: str, group: DocumentGroup) -> None:
+    """Fill ``folder_name`` for the group and for each document that carries a ``folder_id``.
+
+    The entity-level ``folder_id`` is the primary answer; per-document ids are also
+    resolved because a group's members may (rarely, for legacy documents) live in
+    different folders than the group.
+
+    A single ``get_folder_tree`` call returns the whole folder hierarchy — personal
+    and team folders alike — with subfolders nested recursively, indexed into an
+    id→name map. So any folder at any depth is resolved with exactly one API request.
+    A folder absent from the tree (deleted or inaccessible) keeps ``folder_name=None``
+    while retaining the raw ``folder_id``.
+
+    Mutates the group and its documents in place. No-op when nothing has a folder.
+    """
+    if not group.folder_id and not any(doc.folder_id for doc in group.documents):
+        return
+
+    tree = client.get_folder_tree(token)
+    name_by_id: dict[str, str] = {tree.id: tree.name}
+    _index_folder_tree(tree.folders, name_by_id)
+
+    if group.folder_id:
+        group.folder_name = name_by_id.get(group.folder_id)
+    for doc in group.documents:
+        if doc.folder_id:
+            doc.folder_name = name_by_id.get(doc.folder_id)
+
+
+def _get_document(
+    client: SignNowAPIClient,
+    token: str,
+    entity_id: str,
+    entity_type: Literal["document", "document_group", "template", "template_group"] | None = None,
+    *,
+    resolve_folder_names: bool = False,
+) -> DocumentGroup:
     """
     Get document or document group information with full field values.
 
@@ -337,6 +397,9 @@ def _get_document(client: SignNowAPIClient, token: str, entity_id: str, entity_t
         token: Access token for authentication
         entity_id: ID of the document or document group
         entity_type: Type of entity: 'document', 'template', 'template_group' or 'document_group' (optional)
+        resolve_folder_names: When True, resolve each document's folder_name via one extra
+            get_folders call. Callers that don't surface folder info (e.g. signing links)
+            should leave this False to avoid the extra request.
 
     Returns:
         DocumentGroup with complete information including field values
@@ -345,12 +408,21 @@ def _get_document(client: SignNowAPIClient, token: str, entity_id: str, entity_t
         ValueError: If entity not found as either document or document group
     """
 
+    group = _resolve_entity_group(client, token, entity_id, entity_type)
+    if resolve_folder_names:
+        _resolve_folder_names(client, token, group)
+    return group
+
+
+def _resolve_entity_group(client: SignNowAPIClient, token: str, entity_id: str, entity_type: Literal["document", "document_group", "template", "template_group"] | None = None) -> DocumentGroup:
+    """Dispatch to the correct fetcher based on entity_type, auto-detecting when absent."""
+
     # Auto-detect entity type when not provided by probing document → document_group → template_group.
     # Each fallback swallows the prior probe's error because "not found as this type" is the
     # expected negative signal that drives the cascade; the final arm raises if all probes fail.
     if not entity_type:
         try:
-            document_data = client.get_document(token, entity_id)
+            document_data = client.get_document(token, entity_id, is_custom_folder=True)
             return _get_single_document_as_group(client, token, entity_id, document_data)
         except Exception:  # noqa: S110
             pass
@@ -371,7 +443,7 @@ def _get_document(client: SignNowAPIClient, token: str, entity_id: str, entity_t
     if entity_type == "template_group":
         return _get_full_template_group(client, token, client.get_document_group_template(token, entity_id))
     # entity_type == "document" or "template"
-    return _get_single_document_as_group(client, token, entity_id, client.get_document(token, entity_id))
+    return _get_single_document_as_group(client, token, entity_id, client.get_document(token, entity_id, is_custom_folder=True))
 
 
 def _get_single_document_as_group(client: SignNowAPIClient, token: str, document_id: str, document_data: DocumentResponse) -> DocumentGroup:
@@ -404,12 +476,13 @@ def _get_single_document_as_group(client: SignNowAPIClient, token: str, document
             if isinstance(candidate, str) and candidate:
                 freeform_invite_id = candidate
 
-    # Create DocumentGroup with single document
+    # Create DocumentGroup with single document.
     return DocumentGroup(
         last_updated=0,  # Not available for single documents
         entity_id=document_id,
         group_name=full_document.name,
         entity_type="document",
+        folder_id=full_document.folder_id,
         invite=invite,
         freeform_invite_id=freeform_invite_id,
         documents=[full_document],

--- a/src/sn_mcp_server/tools/models.py
+++ b/src/sn_mcp_server/tools/models.py
@@ -110,6 +110,8 @@ class DocumentGroupDocument(BaseModel):
 
     id: str = Field(..., description="Document ID")
     name: str = Field(..., description="Document name")
+    folder_id: str | None = Field(None, description="ID of the folder this document is stored in, if any")
+    folder_name: str | None = Field(None, description="Name of the folder this document is stored in, if it could be resolved")
     roles: list[str] = Field(..., description="Roles defined for this document")
     fields: list[DocumentField] = Field(default=[], description="Fields defined in this document")
 
@@ -121,6 +123,8 @@ class DocumentGroup(BaseModel):
     entity_id: str = Field(..., description="Document group ID")
     group_name: str = Field(..., description="Name of the document group")
     entity_type: str = Field(..., description="Type of entity: 'document' or 'document_group'")
+    folder_id: str | None = Field(None, description="ID of the folder this entity is stored in, if any")
+    folder_name: str | None = Field(None, description="Name of the folder this entity is stored in, if it could be resolved")
     invite: SimplifiedInvite | None = Field(None, description="Unified invite info")
     freeform_invite_id: str | None = Field(None, description="Freeform invite ID, if a freeform invite exists on this entity")
     documents: list[DocumentGroupDocument] = Field(..., description="List of documents in this group")

--- a/src/sn_mcp_server/tools/signnow.py
+++ b/src/sn_mcp_server/tools/signnow.py
@@ -810,7 +810,7 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
         token, client = _get_token_and_client(token_provider)
 
         # Initialize client and use the imported function from document module
-        return _get_document(client, token, entity_id, entity_type)
+        return _get_document(client, token, entity_id, entity_type, resolve_folder_names=True)
 
     @mcp.tool(
         name="get_document",

--- a/tests/unit/signnow_client/test_oauth_and_folders.py
+++ b/tests/unit/signnow_client/test_oauth_and_folders.py
@@ -85,3 +85,19 @@ class TestGetFolderById:
         assert client.last_get is not None
         # order defaults to "desc" and entity_type to "document-all"; no others.
         assert client.last_get["params"] == {"order": "desc", "entity_type": "document-all"}
+
+
+class TestGetFolderTree:
+    def test_requests_full_hierarchy_from_v1_folder(self) -> None:
+        """Hits /v1/folder with the paired subfolder flags (1/0) that unlock full nesting."""
+        client = _DummyClient()
+        client.get_folder_tree("ftok")
+        assert client.last_get is not None
+        assert client.last_get["url"] == "/v1/folder"
+        assert client.last_get["headers"]["Authorization"] == "Bearer ftok"
+        # subfolder-data and include_documents_subfolders must be sent together as 1/0.
+        assert client.last_get["params"] == {
+            "subfolder-data": 1,
+            "include_documents_subfolders": 1,
+            "with_team_documents": "true",
+        }

--- a/tests/unit/sn_mcp_server/tools/test_document.py
+++ b/tests/unit/sn_mcp_server/tools/test_document.py
@@ -625,6 +625,39 @@ class TestGetDocumentFolderResolution:
         assert result.entity_type == "template_group"
         assert [d.folder_name for d in result.documents] == ["Folder 1", "Folder 1"]
 
+    def test_document_group_folder_from_group_response_members_may_differ(self, mock_client: MagicMock) -> None:
+        """The group folder comes from the group's own API response (data.folder_id),
+        while each member keeps its own folder (legacy: members may differ)."""
+        from signnow_client.models.document_groups import (
+            DocumentGroupV2Data,
+            DocumentGroupV2Document,
+            GetDocumentGroupV2Response,
+        )
+
+        data = DocumentGroupV2Data.model_construct(
+            id="dg",
+            name="DG",
+            folder_id="folder2",
+            created=0,
+            state="pending",
+            invite_id=None,
+            pending_step_id=None,
+            last_invite_id=None,
+            documents=[DocumentGroupV2Document.model_construct(id="m1", field_invites=[]), DocumentGroupV2Document.model_construct(id="m2", field_invites=[])],
+            freeform_invite=None,
+        )
+        mock_client.get_document_group_v2.return_value = GetDocumentGroupV2Response.model_construct(data=data)
+        mock_client.get_document.return_value = _make_document_response(parent_id="deep1")
+        mock_client.get_folder_tree.return_value = _folder_tree()
+
+        result = _get_document(mock_client, "tok", "dg", "document_group", resolve_folder_names=True)
+
+        assert result.entity_type == "document_group"
+        assert result.folder_name == "Folder 2"  # group-level, from data.folder_id
+        assert [d.folder_name for d in result.documents] == ["Deep One", "Deep One"]  # member parent_id
+        # members are fetched with is_custom_folder to get their real (immediate) folder
+        assert mock_client.get_document.call_args_list[0].kwargs == {"is_custom_folder": True}
+
     def test_single_document_flow_requests_immediate_folder_and_resolves_nested_name(self, mock_client: MagicMock) -> None:
         """End-to-end: the document fetch asks for the immediate folder (is_custom_folder),
         and its nested folder_id resolves to the real subfolder name via the tree."""

--- a/tests/unit/sn_mcp_server/tools/test_document.py
+++ b/tests/unit/sn_mcp_server/tools/test_document.py
@@ -3,16 +3,22 @@
 from __future__ import annotations
 
 import pathlib
-from unittest.mock import MagicMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from signnow_client.models.folders_lite import FolderLite, GetFoldersResponseLite
 from sn_mcp_server.tools.document import (
+    _get_document,
     _get_full_document,
+    _resolve_folder_names,
     _update_document_fields,
     _upload_document,
 )
 from sn_mcp_server.tools.models import (
+    DocumentGroup,
+    DocumentGroupDocument,
     FieldToUpdate,
     UpdateDocumentFields,
     UpdateDocumentFieldsResponse,
@@ -44,11 +50,13 @@ def _make_document_response(
     roles: list | None = None,
     fields: list | None = None,
     field_invites: list | None = None,
+    parent_id: str | None = None,
 ) -> MagicMock:
     """Build a minimal DocumentResponse mock."""
     doc = MagicMock()
     doc.id = doc_id
     doc.document_name = name
+    doc.parent_id = parent_id
 
     role_objs = []
     for r in roles or ["Signer"]:
@@ -423,3 +431,260 @@ class TestUpdateDocumentFields:
 
         assert result.results == []
         mock_client.prefill_text_fields.assert_not_called()
+
+
+def _folder_tree() -> GetFoldersResponseLite:
+    """Full nested hierarchy as get_folder_tree returns it (subfolders nested recursively)."""
+    return GetFoldersResponseLite(
+        id="root_folder_id",
+        name="Root Folder",
+        user_id="user123",
+        folders=[
+            FolderLite(
+                id="folder1",
+                name="Folder 1",
+                user_id="user123",
+                sub_folders=[
+                    FolderLite(
+                        id="nested1",
+                        name="Nested One",
+                        user_id="user123",
+                        sub_folders=[FolderLite(id="deep1", name="Deep One", user_id="user123")],
+                    ),
+                ],
+            ),
+            FolderLite(id="folder2", name="Folder 2", user_id="user123"),
+            FolderLite(
+                id="team_templates",
+                name="Team Templates",
+                user_id="user123",
+                sub_folders=[FolderLite(id="team_nested", name="Team Nested", user_id="user123")],
+            ),
+        ],
+    )
+
+
+def _doc(doc_id: str = "d1", folder_id: str | None = None) -> DocumentGroupDocument:
+    """Minimal DocumentGroupDocument with an optional folder_id."""
+    return DocumentGroupDocument(id=doc_id, name=f"Doc {doc_id}", folder_id=folder_id, roles=[])
+
+
+def _grp(documents: list[DocumentGroupDocument], folder_id: str | None = None) -> DocumentGroup:
+    """Wrap documents in a DocumentGroup with an optional group-level folder_id."""
+    return DocumentGroup(
+        last_updated=0,
+        entity_id="grp",
+        group_name="G",
+        entity_type="document_group",
+        folder_id=folder_id,
+        invite=None,
+        documents=documents,
+    )
+
+
+class TestResolveFolderNames:
+    """Tests for _resolve_folder_names."""
+
+    @pytest.fixture
+    def mock_client(self) -> MagicMock:
+        return MagicMock()
+
+    def test_noop_when_no_document_has_folder(self, mock_client: MagicMock) -> None:
+        """No document carries a folder_id: skip the folder-tree call entirely."""
+        documents = [_doc("d1"), _doc("d2")]
+
+        _resolve_folder_names(mock_client, "tok", _grp(documents))
+
+        mock_client.get_folder_tree.assert_not_called()
+        assert all(doc.folder_name is None for doc in documents)
+
+    def test_resolves_root_and_top_level(self, mock_client: MagicMock) -> None:
+        """Root and top-level folder ids resolve from the single tree call."""
+        mock_client.get_folder_tree.return_value = _folder_tree()
+        documents = [_doc("d1", folder_id="root_folder_id"), _doc("d2", folder_id="folder2")]
+
+        _resolve_folder_names(mock_client, "tok", _grp(documents))
+
+        mock_client.get_folder_tree.assert_called_once_with("tok")
+        assert documents[0].folder_name == "Root Folder"
+        assert documents[1].folder_name == "Folder 2"
+
+    def test_resolves_deeply_nested_subfolder(self, mock_client: MagicMock) -> None:
+        """A subfolder several levels deep resolves from the nested tree."""
+        mock_client.get_folder_tree.return_value = _folder_tree()
+        documents = [_doc("d1", folder_id="deep1"), _doc("d2", folder_id="folder1")]
+
+        _resolve_folder_names(mock_client, "tok", _grp(documents))
+
+        assert documents[0].folder_name == "Deep One"
+        assert documents[1].folder_name == "Folder 1"
+
+    def test_single_tree_call_regardless_of_folder_count(self, mock_client: MagicMock) -> None:
+        """Any number of folders at any depth is covered by exactly one tree call."""
+        mock_client.get_folder_tree.return_value = _folder_tree()
+        documents = [_doc("d1", folder_id="nested1"), _doc("d2", folder_id="deep1"), _doc("d3", folder_id="folder2")]
+
+        _resolve_folder_names(mock_client, "tok", _grp(documents))
+
+        mock_client.get_folder_tree.assert_called_once_with("tok")
+        assert [d.folder_name for d in documents] == ["Nested One", "Deep One", "Folder 2"]
+
+    def test_resolves_team_subfolder_from_tree(self, mock_client: MagicMock) -> None:
+        """Team-folder subfolders (present in the /v1/folder tree) resolve like any other."""
+        mock_client.get_folder_tree.return_value = _folder_tree()
+        documents = [_doc("d1", folder_id="team_nested")]
+
+        _resolve_folder_names(mock_client, "tok", _grp(documents))
+
+        assert documents[0].folder_name == "Team Nested"
+
+    def test_unknown_folder_keeps_name_none(self, mock_client: MagicMock) -> None:
+        """A folder absent from the tree leaves folder_name None but retains folder_id."""
+        mock_client.get_folder_tree.return_value = _folder_tree()
+        documents = [_doc("d1", folder_id="ghost"), _doc("d2", folder_id="folder1")]
+
+        _resolve_folder_names(mock_client, "tok", _grp(documents))
+
+        assert documents[0].folder_name is None
+        assert documents[0].folder_id == "ghost"
+        assert documents[1].folder_name == "Folder 1"
+
+    def test_resolves_group_level_folder(self, mock_client: MagicMock) -> None:
+        """The entity-level folder_id resolves to folder_name on the group itself."""
+        mock_client.get_folder_tree.return_value = _folder_tree()
+        group = _grp([_doc("d1", folder_id="deep1")], folder_id="folder2")
+
+        _resolve_folder_names(mock_client, "tok", group)
+
+        assert group.folder_name == "Folder 2"
+        assert group.documents[0].folder_name == "Deep One"
+
+    def test_group_folder_resolved_even_with_no_document_folders(self, mock_client: MagicMock) -> None:
+        """Group folder resolves even when no member document carries a folder_id."""
+        mock_client.get_folder_tree.return_value = _folder_tree()
+        group = _grp([_doc("d1")], folder_id="folder1")
+
+        _resolve_folder_names(mock_client, "tok", group)
+
+        assert group.folder_name == "Folder 1"
+
+
+class TestGetDocumentFolderResolution:
+    """Tests for the resolve_folder_names flag on _get_document."""
+
+    @pytest.fixture
+    def mock_client(self) -> MagicMock:
+        return MagicMock()
+
+    def _group(self) -> DocumentGroup:
+        return DocumentGroup(
+            last_updated=0,
+            entity_id="grp",
+            group_name="Group",
+            entity_type="document",
+            folder_id="folder2",
+            invite=None,
+            documents=[_doc("d1", folder_id="deep1")],
+        )
+
+    def test_resolves_folder_names_when_flag_true(self, mock_client: MagicMock) -> None:
+        mock_client.get_folder_tree.return_value = _folder_tree()
+
+        with patch("sn_mcp_server.tools.document._resolve_entity_group", return_value=self._group()):
+            result = _get_document(mock_client, "tok", "grp", "document", resolve_folder_names=True)
+
+        assert result.folder_name == "Folder 2"
+        assert result.documents[0].folder_name == "Deep One"
+        mock_client.get_folder_tree.assert_called_once_with("tok")
+
+    def test_skips_folder_resolution_when_flag_false(self, mock_client: MagicMock) -> None:
+        with patch("sn_mcp_server.tools.document._resolve_entity_group", return_value=self._group()):
+            result = _get_document(mock_client, "tok", "grp", "document")
+
+        assert result.folder_name is None
+        assert result.documents[0].folder_name is None
+        mock_client.get_folder_tree.assert_not_called()
+
+    def test_template_group_surfaces_group_folder_on_members(self, mock_client: MagicMock) -> None:
+        """A template group's members carry no folder of their own, so the group folder
+        (from the DGT response) is surfaced on each and resolved to its name."""
+        from signnow_client.models.document_groups import GetDocumentGroupTemplateResponse, TemplateShort
+
+        tg = GetDocumentGroupTemplateResponse.model_construct(
+            id="tg",
+            group_name="TG",
+            folder_id="folder1",
+            templates=[TemplateShort.model_construct(id="t1"), TemplateShort.model_construct(id="t2")],
+        )
+        mock_client.get_document_group_template.return_value = tg
+        mock_client.get_document.return_value = _make_document_response(parent_id=None)
+        mock_client.get_folder_tree.return_value = _folder_tree()
+
+        result = _get_document(mock_client, "tok", "tg", "template_group", resolve_folder_names=True)
+
+        assert result.entity_type == "template_group"
+        assert [d.folder_name for d in result.documents] == ["Folder 1", "Folder 1"]
+
+    def test_single_document_flow_requests_immediate_folder_and_resolves_nested_name(self, mock_client: MagicMock) -> None:
+        """End-to-end: the document fetch asks for the immediate folder (is_custom_folder),
+        and its nested folder_id resolves to the real subfolder name via the tree."""
+        mock_client.get_document.return_value = _make_document_response(doc_id="docid", parent_id="deep1")
+        mock_client.get_folder_tree.return_value = _folder_tree()
+
+        # entity_type=None exercises the auto-detect probe (the common get_document path).
+        result = _get_document(mock_client, "tok", "docid", None, resolve_folder_names=True)
+
+        mock_client.get_document.assert_called_once_with("tok", "docid", is_custom_folder=True)
+        assert result.documents[0].folder_id == "deep1"
+        assert result.documents[0].folder_name == "Deep One"
+
+
+def _capture_get_document_tool() -> Any:
+    """Register the signnow tools and return the get_document tool function."""
+    from fastmcp import FastMCP
+
+    from sn_mcp_server.tools import signnow
+
+    mcp: Any = FastMCP("test-get-document")
+    captured: dict[str, Any] = {}
+    original_tool = mcp.tool
+
+    def recording_tool(*args: Any, **kwargs: Any) -> Any:
+        decorator = original_tool(*args, **kwargs)
+        tool_name: str = kwargs.get("name", "")
+
+        def wrap(fn: Any) -> Any:
+            captured[tool_name] = fn
+            return decorator(fn)
+
+        return wrap
+
+    mcp.tool = recording_tool
+    signnow.bind(mcp, None)
+    return captured["get_document"]
+
+
+class TestGetDocumentTool:
+    """Tests for the get_document MCP tool wrapper."""
+
+    async def test_requests_folder_name_resolution(self) -> None:
+        """The tool delegates to _get_document with resolve_folder_names=True."""
+        tool = _capture_get_document_tool()
+        ctx = AsyncMock()
+        expected = DocumentGroup(
+            last_updated=0,
+            entity_id="grp",
+            group_name="Group",
+            entity_type="document",
+            invite=None,
+            documents=[],
+        )
+
+        with (
+            patch("sn_mcp_server.tools.signnow._get_token_and_client", return_value=("tok", MagicMock())),
+            patch("sn_mcp_server.tools.signnow._get_document", return_value=expected) as mock_get,
+        ):
+            result = tool(ctx, "grp", "document")
+
+        assert result == expected
+        assert mock_get.call_args.kwargs["resolve_folder_names"] is True

--- a/tests/unit/sn_mcp_server/tools/test_send_invite.py
+++ b/tests/unit/sn_mcp_server/tools/test_send_invite.py
@@ -345,7 +345,7 @@ class TestSendDocumentFreeformInvite:
             MagicMock(id="inv_c"),
         ]
         mock_client.cfg.app_base = "https://app.test.signnow.com"
-        mock_client.get_document.return_value = MagicMock(fields=[], template=False, id="doc1", document_name="doc", roles=[])
+        mock_client.get_document.return_value = MagicMock(fields=[], template=False, id="doc1", document_name="doc", roles=[], parent_id=None)
         orders = [
             InviteOrder(
                 order=1,
@@ -587,7 +587,7 @@ class TestSendInviteSelfSign:
 
     async def test_self_sign_builds_synthetic_orders_from_user_info(self, mock_client: MagicMock) -> None:
         """When self_sign=True and entity has no fields, the tool fills in the user as sole recipient and returns a SendInviteResponse whose link is populated."""
-        mock_client.get_document.return_value = MagicMock(fields=[], template=False, id="doc1", document_name="doc")
+        mock_client.get_document.return_value = MagicMock(fields=[], template=False, id="doc1", document_name="doc", parent_id=None)
         mock_client.get_user_info.return_value = MagicMock(primary_email="me@co.com")
         mock_client.create_document_freeform_invite.return_value = MagicMock(id="self_inv")
 
@@ -617,7 +617,7 @@ class TestSendInviteSelfSign:
         # is already empty (the wrapper passes []).
         mock_client = MagicMock()
         mock_client.cfg.app_base = "https://app.test.signnow.com"
-        mock_client.get_document.return_value = MagicMock(fields=[], template=False, id="doc1", document_name="doc")
+        mock_client.get_document.return_value = MagicMock(fields=[], template=False, id="doc1", document_name="doc", parent_id=None)
         mock_client.get_user_info.return_value = MagicMock(primary_email="me@co.com")
         mock_client.create_document_freeform_invite.return_value = MagicMock(id="inv")
 


### PR DESCRIPTION
## Summary

`get_document` now returns the folder each entity lives in — for documents, templates, document groups, and document group templates — with the real folder name resolved at any depth (nested subfolders, personal and team folders). Previously folder info was missing or wrong: `get_document` reported only the top-level system folder instead of the immediate/nested one, nested subfolder names never resolved, and document group templates showed no folder at all. Agents need to know where an entity actually lives to reason about it and present it to users, so the folder is now sourced from each entity's own API response and resolved in a single request — while per-member folders are kept for the rare legacy case where a group's members sit in a different folder than the group.

## Changes

- **Immediate folder, not top-level.** Documents/templates are fetched with `is_custom_folder`, so `parent_id` is the document's immediate (possibly nested) folder instead of the top-level system folder.
- **Full hierarchy in one call.** Folder names are resolved via a single `GET /v1/folder` tree request (`subfolder-data=1` & `include_documents_subfolders=1`), which returns every descendant recursively — personal and team folders alike — indexed into an id→name map. `FolderLite` now parses the nested `sub_folders` the model previously discarded.
- **Folder at the entity level.** `folder_id`/`folder_name` added to `DocumentGroup`, sourced from the entity's own API response — `data.folder_id` for document groups, `folder_id` for template groups, and the document's `parent_id` for a single document (a group of one). Never derived from member documents.
- **Per-document folder retained.** `DocumentGroupDocument.folder_id`/`folder_name` stay in place because a group's members may (rarely, for legacy documents) live in a different folder than the group. Resolution fills the group folder and every member folder from the same single tree call.
- **Template-group folder.** `folder_id` is now parsed from the document-group-template response and surfaced on the group and its member templates.

## Tests

- Unit tests for `_resolve_folder_names`: root, top-level, deeply nested, team subfolders, unknown-id → `None`, group-level resolution, and the single-tree-call invariant.
- End-to-end `get_document` flow tests for a single document, a document group (group folder from the group response; members may differ), and a template group (group folder surfaced on members).
- Client test for `get_folder_tree` (paired `subfolder-data`/`include_documents_subfolders` flags).
- Diff coverage on changed lines: **100%**.
