### PR TITLE
Drop access token from signing links

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -270,7 +270,6 @@ Tools that operate on both documents and document groups use a try/except ladder
 | `auth.py` module scope | Lazy initialization | Config load + RSA keygen + client creation at import time | High — side effects on import, hard to test |
 | `auth.py` `REGISTERED_CLIENTS` | Stateless server | Mutable module-level dict (declared but unused) | Low — dead code, principle violation |
 | `tools/signnow.py` `get_http_headers` | Transport-agnostic tools | Imports from `fastmcp.server.dependencies` | Medium — couples orchestration to transport |
-| `signing_link.py` | Secure token handling | Access token in URL query string | Medium — security concern |
 | `tools/__init__.py` `cfg` param | Config propagation | Accepted but never used in `bind()` | Low — dead parameter |
 | Entity detection order | Consistent order across tools | `get_document` tries document first, others try group first | Medium — inconsistent behavior |
 | Both `/sse` and `/mcp` | Single transport per endpoint | Legacy and modern transports both active | Low — backwards compat |

--- a/src/sn_mcp_server/tools/signing_link.py
+++ b/src/sn_mcp_server/tools/signing_link.py
@@ -39,9 +39,9 @@ def _get_signing_link(entity_id: str, entity_type: Literal["document", "document
     resolved_entity_id = document_group.entity_id
 
     if document_group.entity_type == "document_group":
-        query = urlencode({"document_group_id": resolved_entity_id, "access_token": token})
+        query = urlencode({"document_group_id": resolved_entity_id})
         link = f"{app_base}/webapp/documentgroup/signing?{query}&unwrap"
     else:
-        link = f"{app_base}/webapp/document/{resolved_entity_id}?access_token={token}"
+        link = f"{app_base}/webapp/document/{resolved_entity_id}"
 
     return SigningLinkResponse(link=link)

--- a/tests/integration/test_send_invite.py
+++ b/tests/integration/test_send_invite.py
@@ -303,7 +303,7 @@ class TestSendInviteSelfSign:
         assert result.invite_entity == "document"
         assert result.link is not None
         assert SELF_SIGN_DOC_ID in result.link
-        assert token in result.link  # link embeds access token
+        assert token not in result.link  # link must not embed the access token
 
         # ASSERT — request body: to == from == primary_email from the user fixture.
         body = json.loads(invite_route.calls[0].request.content)

--- a/tests/unit/sn_mcp_server/tools/test_signing_link.py
+++ b/tests/unit/sn_mcp_server/tools/test_signing_link.py
@@ -69,7 +69,7 @@ class TestGetSigningLinkInviteCheck:
         with patch("sn_mcp_server.tools.signing_link._get_document", return_value=dg):
             result = _get_signing_link("doc1", "document", FAKE_TOKEN, client)
 
-        assert result.link == f"{APP_BASE}/webapp/document/doc1?access_token={FAKE_TOKEN}"
+        assert result.link == f"{APP_BASE}/webapp/document/doc1"
 
     def test_document_with_only_freeform_invite_returns_link(self) -> None:
         """Document whose only invite is freeform (requests[]) still produces a link."""
@@ -79,7 +79,7 @@ class TestGetSigningLinkInviteCheck:
         with patch("sn_mcp_server.tools.signing_link._get_document", return_value=dg):
             result = _get_signing_link("doc1", "document", FAKE_TOKEN, client)
 
-        assert result.link == f"{APP_BASE}/webapp/document/doc1?access_token={FAKE_TOKEN}"
+        assert result.link == f"{APP_BASE}/webapp/document/doc1"
 
     def test_document_group_with_only_freeform_invite_returns_link(self) -> None:
         """Document group whose only invite is freeform_invite still produces a link."""
@@ -90,8 +90,23 @@ class TestGetSigningLinkInviteCheck:
             result = _get_signing_link("grp1", "document_group", FAKE_TOKEN, client)
 
         assert "document_group_id=grp1" in result.link
-        assert f"access_token={FAKE_TOKEN}" in result.link
         assert result.link.endswith("&unwrap")
+
+    def test_links_do_not_leak_access_token(self) -> None:
+        """Neither the document nor the document_group link may embed the access token."""
+        client = _make_client()
+        doc = _make_document_group(entity_type="document", invite=SimplifiedInvite(invite_id="inv1"))
+        grp = _make_document_group(entity_id="grp1", entity_type="document_group", freeform_invite_id="freeform-xyz")
+
+        with patch("sn_mcp_server.tools.signing_link._get_document", return_value=doc):
+            doc_link = _get_signing_link("doc1", "document", FAKE_TOKEN, client).link
+        with patch("sn_mcp_server.tools.signing_link._get_document", return_value=grp):
+            grp_link = _get_signing_link("grp1", "document_group", FAKE_TOKEN, client).link
+
+        assert "access_token" not in doc_link
+        assert FAKE_TOKEN not in doc_link
+        assert "access_token" not in grp_link
+        assert FAKE_TOKEN not in grp_link
 
     def test_document_group_with_classic_invite_returns_link(self) -> None:
         """Document group with a classic invite produces the documentgroup signing URL."""


### PR DESCRIPTION
## Summary

Signing links generated by `get_signing_link` (and reused by the `send_invite` self-sign flow) previously embedded the raw SignNow access token directly in the URL query string. Access tokens in URLs leak through server/proxy logs, browser history, and `Referer` headers, so this PR removes the token from the generated links. This resolves the `signing_link.py` "Access token in URL query string" row that ARCHITECTURE.md itself flagged as a security concern.

This was the only place in our code that manually appended a token to a link — the embedded view/editor/sending links come pre-signed from the SignNow API and are untouched.

## Changes

- **`tools/signing_link.py`** — remove `access_token` from both branches:
  - `document` → `{app_base}/webapp/document/{id}`
  - `document_group` → `{app_base}/webapp/documentgroup/signing?document_group_id={id}&unwrap`
- **`tests/unit/.../test_signing_link.py`** — expect token-free links; add `test_links_do_not_leak_access_token` regression test.
- **`tests/integration/test_send_invite.py`** — self-sign link assertion flipped to `token not in result.link`.
- **`ARCHITECTURE.md`** — drop the now-resolved security-concern row from "Known deviations".

## Tests

`pytest tests/` → 857 passed, 1 skipped. Ruff, mypy, and import-linter all green (pre-commit + pre-push hooks passed).

## ⚠️ Behavioral note

The signing link no longer auto-authenticates the opener via the URL token — the recipient must be signed in to the SignNow web app (or will be prompted to). If a seamless open-and-sign UX is required, the correct path is to generate an embedded-signing link via the API rather than appending a token to the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)