### PR TITLE
Clarify get_signing_link is for self-signing only

### DIFF
--- a/src/sn_mcp_server/tools/signnow.py
+++ b/src/sn_mcp_server/tools/signnow.py
@@ -777,7 +777,12 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
     @mcp.tool(
         name="get_signing_link",
         version="1.0",
-        description="Get signing link for a document or document group",
+        description=(
+            "Get a signing link for the CURRENT (authenticated) user to sign a document or document group themselves. "
+            "Use this only when the user wants to sign the document on their own. "
+            "This is NOT for sending a document to someone else for signature — for that, use send_invite "
+            "(email invite) or the embedded invite tools instead."
+        ),
         annotations=ToolAnnotations(
             title="Get signing link",
             readOnlyHint=True,
@@ -795,7 +800,10 @@ def bind(mcp: Any, cfg: Any) -> None:  # noqa: ANN401
             Field(description="Type of entity: 'document' or 'document_group' (optional). If you're passing it, make sure you know what type you have. If it's not found, try using a different type."),
         ] = None,
     ) -> SigningLinkResponse:
-        """Get signing link for a document or document group.
+        """Get a signing link for the current (authenticated) user to sign a document or document group.
+
+        Use this only when the user wants to sign the document themselves. It is NOT for sending a
+        document to another person for signature — use send_invite or the embedded invite tools for that.
 
         Args:
             entity_id: ID of the document or document group


### PR DESCRIPTION
## Summary

Clarifies the intent of the `get_signing_link` tool. The returned link is meant for the **current (authenticated) user to sign the document themselves** — it is not a way to send a document to another person for signature. Without this in the description, an agent can mistakenly reach for `get_signing_link` when the user actually wants to send a document out for signing.

Follow-up to #65 (which removed the access token from these links).

## Changes

- `tools/signnow.py` — expand the `get_signing_link` tool `description` and docstring to state it is for self-signing only, and point to `send_invite` / the embedded invite tools for sending a document to someone else.

## Tests

Docs/description-only change to an existing tool; no behavior change. `pytest tests/unit/` → 759 passed, 1 skipped; ruff + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)